### PR TITLE
Adding Taxonomy object

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -987,6 +987,64 @@
             "type": "object",
             "description": "This is the source information (who discovered it, who researched it, etc.) and optionally a chain of CNA information (e.g. the originating CNA and subsequent parent CNAs who have processed it before it arrives at the MITRE root).\n Must contain: IF this is in the root level it MUST contain a CNA_chain entry, IF this source entry is NOT in the root (e.g. it is part of a vendor statement) then it must contain at least one type of data entry.\n Mandatory in: none | Optional in: all containers",
             "minProperties": 1
+        },
+        "taxonomyMappings": {
+            "type": "array",
+            "description": "List of taxonomy items related to the vulnerability",
+            "minitems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "description": "",
+                "required": [
+                    "taxonomyName",
+                    "taxonomyRelations"
+                ],
+                "properties": {
+                    "taxonomyName": {
+                        "type": "string",
+                        "description": "The name of the taxonomy",
+                        "minLength": 1
+                    },
+                    "taxonomyVersion": {
+                        "type": "string",
+                        "description": "The version of taxonomy the identifiers come from.",
+                        "minLength": 1
+                    },
+                    "taxonomyRelations": {
+                        "type": "array",
+                        "description": "",
+                        "minitems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "object",
+                            "description": "List of relationships to the taxonomy for the vulnerability.  Relationships can be between the taxonomy and the CVE or two taxonomy items",
+                            "required": [
+                                "taxonomyId",
+                                "relationshipName",
+                                "relationshipValue"
+                            ],
+                            "properties": {
+                                "taxonomyId": {
+                                    "type": "string",
+                                    "description": "Identifier of the item in the taxonomy.  Used as the subject of the relationship.",
+                                    "minLength": 1
+                                },
+                                "relationshipName": {
+                                    "type": "string",
+                                    "description": "A description of the relationship",
+                                    "minLength": 1
+                                },
+                                "relationshipValue": {
+                                    "type": "string",
+                                    "description": "The target of the relationship.  Can be the CVE ID or another taxonomy identifier",
+                                    "minLength": 1
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "oneOf": [

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -1004,12 +1004,14 @@
                     "taxonomyName": {
                         "type": "string",
                         "description": "The name of the taxonomy",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 128
                     },
                     "taxonomyVersion": {
                         "type": "string",
                         "description": "The version of taxonomy the identifiers come from.",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 128
                     },
                     "taxonomyRelations": {
                         "type": "array",
@@ -1028,17 +1030,20 @@
                                 "taxonomyId": {
                                     "type": "string",
                                     "description": "Identifier of the item in the taxonomy.  Used as the subject of the relationship.",
-                                    "minLength": 1
+                                    "minLength": 1,
+                                    "maxLength": 2000
                                 },
                                 "relationshipName": {
                                     "type": "string",
-                                    "description": "A description of the relationship",
-                                    "minLength": 1
+                                    "description": "A description of the relationship"
+                                    "minLength": 1,
+                                    "maxLength": 128
                                 },
                                 "relationshipValue": {
                                     "type": "string",
                                     "description": "The target of the relationship.  Can be the CVE ID or another taxonomy identifier",
-                                    "minLength": 1
+                                    "minLength": 1,
+                                    "maxLength": 2000
                                 }
                             }
                         }

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -36,28 +36,7 @@
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
-                        "description": "A tag describing the referenced content; such as 'vendor-advisory', 'mitigation', or 'exploit'.  Official reference tags are subject to approval, while tags starting with 'x_' can be used without approval.",
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 40,
-                        "examples": [
-                            "Broken Link",
-                            "Exploit",
-                            "Issue Tracking",
-                            "Mailing List",
-                            "Mitigation",
-                            "Not Applicable",
-                            "Patch",
-                            "Permissions Required",
-                            "Press/Media Coverage",
-                            "Product",
-                            "Release Notes",
-                            "Technical Description",
-                            "Third Party Advisory",
-                            "Tool Signature",
-                            "VDB Entry",
-                            "Vendor Advisory"
-                        ]
+                        "$ref": "file:tags/reference_tags.json"
                     }
                 }
             }
@@ -971,6 +950,12 @@
             "description": "This is the source information (who discovered it, who researched it, etc.) and optionally a chain of CNA information (e.g. the originating CNA and subsequent parent CNAs who have processed it before it arrives at the MITRE root).\n Must contain: IF this is in the root level it MUST contain a CNA_chain entry, IF this source entry is NOT in the root (e.g. it is part of a vendor statement) then it must contain at least one type of data entry.",
             "minProperties": 1
         },
+        "language": {
+            "type": "string",
+            "description": "BCP 47 language code, language-region",
+            "default": "en",
+            "pattern": "^[A-Za-z]{2,4}([_-][A-Za-z]{4})?([_-]([A-Za-z]{2}|[0-9]{3}))?$"
+        },
         "taxonomyMappings": {
             "type": "array",
             "description": "List of taxonomy items related to the vulnerability",
@@ -1033,13 +1018,6 @@
                     }
                 }
             }
-        }
-        "language": {
-            "type": "string",
-            "description": "BCP 47 language code, language-region",
-            "default": "en",
-            "pattern": "^[A-Za-z]{2,4}([_-][A-Za-z]{4})?([_-]([A-Za-z]{2}|[0-9]{3}))?$"
-
         }
     },
     "oneOf": [

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -5,34 +5,38 @@
     "title": "",
     "description": "a CVE entry",
     "definitions": {
+        "uriType": {
+            "description": "A universal resource identifier (URI), according to [RFC 3986](https://tools.ietf.org/html/rfc3986).",
+            "type": "string",
+            "format": "uri",
+            "minLength": 1
+        },
+        "uuidType": {
+            "description": "A version 4 (random) universally unique identifier (UUID) as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.3).",
+            "type": "string",
+            "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$"
+        },
         "reference": {
             "type": "object",
-            "required": [
-                "url"
-            ],
+            "required": ["url"],
             "properties": {
                 "url": {
-                    "maxLength": 500,
-                    "minLength": 5,
-                    "type": "string",
-                    "pattern": "^(ftp|http)s?://\\S+$"
+                    "description": "The uniform resource locator (URL), according to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-1.1.3), that can be used to retrieve the referenced resource.",
+                    "$ref": "#/definitions/uriType"
                 },
                 "name": {
+                    "description": "User created name for the reference, often the title of the page.",
                     "type": "string",
                     "maxLength": 500,
                     "minLength": 1
                 },
-                "refSource": {
-                    "type": "string",
-                    "maxLength": 500,
-                    "minLength": 1,
-                    "description": "name of the source, program, etc that produced the URL."
-                },
                 "tags": {
+                    "description": "an array of one or more tags that describe the resource referenced by 'url'.",
                     "type": "array",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
+                        "description": "A tag describing the referenced content; such as 'vendor-advisory', 'mitigation', or 'exploit'.  Official reference tags are subject to approval, while tags starting with 'x_' can be used without approval.",
                         "type": "string",
                         "minLength": 1,
                         "maxLength": 40,
@@ -60,22 +64,24 @@
         },
         "cveId": {
             "type": "string",
-            "pattern": "^CVE-[0-9]{4}-[0-9]{4,}$"
+            "pattern": "^CVE-[0-9]{4}-[0-9]{4,19}$"
         },
         "orgId": {
-            "type": "string",
-            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+            "description": "a UUID for an organization participating in the CVE program. This UUID can be used to lookup the organization record in the user registry service.",
+            "$ref": "#/definitions/uuidType"
         },
         "userId": {
-            "type": "string",
-            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+            "description": "a UUID for a user participating in the CVE program. This UUID can be used to lookup the user record in the user registry service.",
+            "$ref": "#/definitions/uuidType"
         },
         "shortName": {
+            "$comment": "TODO: description needed",
             "type": "string",
             "minLength": 3,
             "maxLength": 12
         },
         "datestamp": {
+            "description": "Date/time format based on RFC3339 and ISO ISO8601",
             "type": "string",
             "format": "date",
             "pattern": "^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))$"
@@ -83,12 +89,12 @@
         "timestamp": {
             "type": "string",
             "format": "date-time",
-            "description": "Date/time format based on RFC3339 and ISO ISO8601, with an optional timezone. yyyy-MM-ddTHH:mm:ssZZZZ  - if timezone offset is not given, GMT (0000) is assumed.",
+            "description": "Date/time format based on RFC3339 and ISO ISO8601, with an optional timezone in the format 'yyyy-MM-ddTHH:mm:ssZZZZ'. If timezone offset is not given, GMT (0000) is assumed.",
             "pattern": "^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})?$"
         },
         "product": {
             "type": "object",
-            "description": "",
+            "description": "Provides information about the set of products and services affected by this vulnerability.",
             "required": [
                 "productName",
                 "versions"
@@ -97,7 +103,8 @@
                 "productName": {
                     "type": "string",
                     "description": "Name of the affected product.",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 2058
                 },
                 "modules": {
                     "type": "array",
@@ -106,7 +113,8 @@
                     "items": {
                         "type": "string",
                         "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "programFiles": {
@@ -114,9 +122,8 @@
                     "description": "A list of the affected source code files (optional)",
                     "uniqueItems": true,
                     "items": {
-                        "type": "uri",
                         "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
-                        "minLength": 1
+                        "$ref": "#/definitions/uriType"
                     }
                 },
                 "programRoutines": {
@@ -126,15 +133,19 @@
                     "items": {
                         "type": "string",
                         "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional).",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
-                "collectionURL": {
+                "packageName": {
                     "type": "string",
+                    "description": "Name or identifier of the affected software package as used in the package collection (optional).",
+                    "minLength": 1,
+                    "maxLength": 2058
+                 },
+                "collectionURL": {
                     "description": "A URL that, among the users of the software package collection, is considered the most popular starting point for accessing the collection (optional).",
-                    "maxLength": 500,
-                    "minLength": 5,
-                    "pattern": "^(ftp|http)s?://\\S+$",
+                    "$ref": "#/definitions/uriType",
                     "examples": [
                         "https://access.redhat.com/downloads/content/package-browser",
                         "https://addons.mozilla.org",
@@ -203,29 +214,29 @@
                 },
                 "versions": {
                     "type": "array",
-                    "description": "",
+                    "description": "Set of product versions related to the vulnerability. The versions satisfy the CNA Rules [8.1.2 requirement](https://cve.mitre.org/cve/cna/rules.html#section_8-1_cve_entry_information_requirements).",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
                         "type": "object",
                         "description": "Affected/non-affected/fixed versions of a given technology, product, hardware, etc.",
-                        "required": [
-                            "versionValue"
-                        ],
+                        "required": ["versionValue"],
                         "properties": {
                             "versionGroup": {
                                 "type": "string",
                                 "description": "A string that represents a version branch, group, or a major version (e.g. 10.0, 3.1.*) where all version values are typically sequential or versionAffected comparisons are meaningful (optional).",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 1024
                             },
                             "versionValue": {
                                 "type": "string",
                                 "description": "The version name/value (e.g. 10.0.1, 3.1.2, \"IceHouse\")",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 1024
                             },
                             "versionAffected": {
                                 "type": "string",
-                                "description": "A string value:\n \"=\" (affects versionValue),\n \">\" (affects versions prior to versionValue),\n \">\" (affects versions later than versionValue),\n \"<=\" (affects versionValue and prior versions),\n \">=\" (affects versionValue and later versions),\n \"!\" (doesn't affect versionValue),\n \"!<\" (doesn't affect versions prior to versionValue),\n \"!>\" (doesn't affect versions later than versionValue),\n \"!<=\" (doesn't affect versionValue and prior versions),\n \"!>=\" (doesn't affect versionValue and later versions),\n \"?\" (status of versionValue is unknown),\n \"?<\" (status of versions prior to versionValue is unknown),\n \"?>\" (status of versions later than versionValue is unknown),\n \"?<=\" (status of versionValue and prior versions is unknown),\n \"?>=\" (status of versionValue and later versions is unknown)",
+                                "description": "A string value:\n \"=\" (affects versionValue),\n \"<\" (affects versions prior to versionValue),\n \">\" (affects versions later than versionValue),\n \"<=\" (affects versionValue and prior versions),\n \">=\" (affects versionValue and later versions),\n \"!\" (doesn't affect versionValue),\n \"!<\" (doesn't affect versions prior to versionValue),\n \"!>\" (doesn't affect versions later than versionValue),\n \"!<=\" (doesn't affect versionValue and prior versions),\n \"!>=\" (doesn't affect versionValue and later versions),\n \"?\" (status of versionValue is unknown),\n \"?<\" (status of versions prior to versionValue is unknown),\n \"?>\" (status of versions later than versionValue is unknown),\n \"?<=\" (status of versionValue and prior versions is unknown),\n \"?>=\" (status of versionValue and later versions is unknown)",
                                 "enum": [
                                     "=",
                                     "<",
@@ -244,35 +255,27 @@
                                     "?>="
                                 ]
                             },
-                            "references": {
-                                "$ref": "#/definitions/references"
+                            "references": {"$ref": "#/definitions/references"}
                             }
                         }
                     }
                 }
-            }
         },
         "dataType": {
+            "description": "Indicates the type of information represented in the JSON instance.",
             "type": "string",
             "enum": [
-                "CVE"
-            ]
-        },
-        "dataFormat": {
-            "type": "string",
-            "enum": [
-                "MITRE"
+                "CVE_RECORD"
             ]
         },
         "dataVersion": {
+            "description": "The version of the schema being used. Used to support multiple versions of this format.",
             "type": "string",
-            "enum": [
-                "5.0"
-            ]
+            "enum": ["5.0"]
         },
-        "cveDataMetaPublic": {
-            "type": "object",
+        "cveMetadataPublic": {
             "description": "This is meta data about the CVE ID such as the CVE ID, who requested it, who assigned it, when it was requested, when it was assigned, the current state (PUBLIC, REJECT, etc.) and so on.",
+            "type": "object",
             "required": [
                 "id",
                 "assigner",
@@ -280,11 +283,12 @@
             ],
             "properties": {
                 "id": {
+                    "description": "The CVE identifier that this record pertains to.",
                     "$ref": "#/definitions/cveId"
                 },
                 "assigner": {
                     "$ref": "#/definitions/orgId",
-                    "description": "the UUID for the organization to which the CVE ID was originally assigned"
+                    "description": "the UUID for the organization to which the CVE ID was originally assigned. This UUID can be used to lookup the organization record in the user registry service."
                 },
                 "assignerShortName": {
                     "$ref": "#/definitions/shortName",
@@ -292,9 +296,10 @@
                 },
                 "requester": {
                     "$ref": "#/definitions/userId",
-                    "description": " the requester of the CVE"
+                    "description": "the user that requested the CVE identifier"
                 },
                 "updated": {
+                    "description": "the date/time the record was last updated",
                     "$ref": "#/definitions/timestamp"
                 },
                 "serial": {
@@ -312,29 +317,32 @@
                 },
                 "datePublic": {
                     "$ref": "#/definitions/timestamp",
-                    "description": "the date/time this went public if known"
+                    "description": "if known, the date/time the vulnerability was disclosed publicly."
                 },
                 "replacedBy": {
-                    "type": "string",
-                    "description": "a single CVE ID or list of CVE IDs (comma separated)",
-                    "pattern": "^(CVE-[0-9]{4}-[0-9]{4,})\\s*(,\\s*CVE-[0-9]{4}-[0-9]{4,})*$"
+                    "type": "array",
+                    "description": "an array of CVE IDs",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/cveId"
+                    }
                 },
                 "state": {
-                    "type": "string",
                     "description": "State of CVE - PUBLIC, RESERVED, REJECT",
-                    "enum": [
-                        "PUBLIC"
-                    ]
+                    "type": "string",
+                    "enum": ["PUBLIC"]
                 },
                 "title": {
                     "type": "string",
                     "description": "Short title - if the description is long we may want a short title to refer to",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 128
                 }
             },
             "additionalProperties": false
         },
-        "cveDataMetaReserved": {
+        "cveMetadataReserved": {
             "type": "object",
             "description": "This is meta data about the CVE ID such as the CVE ID, who requested it, who assigned it, when it was requested, when it was assigned, the current state (PUBLIC, REJECT, etc.) and so on.",
             "required": [
@@ -343,6 +351,7 @@
             ],
             "properties": {
                 "id": {
+                    "description": "The CVE identifier that this record pertains to",
                     "$ref": "#/definitions/cveId"
                 },
                 "assigner": {
@@ -356,21 +365,17 @@
                 "state": {
                     "type": "string",
                     "description": "State of CVE - PUBLIC, RESERVED, REJECT",
-                    "enum": [
-                        "RESERVED"
-                    ]
+                    "enum": ["RESERVED"]
                 },
                 "datePublic": {
                     "$ref": "#/definitions/datestamp",
                     "description": "Anticipated date for public release (YYYY-MM-DD)."
                 },
-                "descriptions": {
-                    "$ref": "#/definitions/descriptions"
-                }
+                "descriptions": {"$ref": "#/definitions/descriptions"}
             },
             "additionalProperties": false
         },
-        "cveDataMetaReject": {
+        "cveMetadataReject": {
             "type": "object",
             "description": "This is meta data about the CVE ID such as the CVE ID, who requested it, who assigned it, when it was requested, when it was assigned, the current state (PUBLIC, REJECT, etc.) and so on.",
             "required": [
@@ -380,6 +385,7 @@
             ],
             "properties": {
                 "id": {
+                    "description": "The CVE identifier that this record pertains to",
                     "$ref": "#/definitions/cveId"
                 },
                 "assigner": {
@@ -393,17 +399,13 @@
                 "state": {
                     "type": "string",
                     "description": "State of CVE - PUBLIC, RESERVED, REJECT",
-                    "enum": [
-                        "REJECT"
-                    ]
+                    "enum": ["REJECT"]
                 },
-                "descriptions": {
-                    "$ref": "#/definitions/descriptions"
-                }
+                "descriptions": {"$ref": "#/definitions/descriptions"}
             },
             "additionalProperties": false
         },
-        "providerDataMeta": {
+        "providerMetadata": {
             "type": "object",
             "description": "will be updated to coordinate with CVE user registry, current identifier is an email address.",
             "properties": {
@@ -417,18 +419,17 @@
                 },
                 "updated": {
                     "$ref": "#/definitions/timestamp",
-                    "description": "Timestamp to be set by system of record at time of submission. If  UPDATED is provided to the system of record it will be replaced by the timestamp at the time of submission. If a provider has multiple contributions, they shall be consolidated to a final single contribution before submission, or the system of record will reject the input with, Rejected – simultaneous contributions by a single provider."
+                    "description": "Timestamp to be set by the system of record at time of submission. If updated is provided to the system of record it will be replaced by the current timestamp at the time of submission. If a provider has multiple contributions, they shall be consolidated to a final single contribution before submission, or the system of record will reject the input with, Rejected \u2013 simultaneous contributions by a single provider."
                 }
             },
-            "required": [
-                "id"
-            ]
+            "required": ["id"]
         },
         "cnaContainer": {
+            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA). There can only be one CNA container per CVE record since there can only be one assigning CNA. The CNA container must include the required information defined in the CVE Rules, which includes a product, version, problem type, prose description, and a reference.",
             "type": "object",
             "properties": {
-                "providerDataMeta": {
-                    "$ref": "#/definitions/providerDataMeta"
+                "providerMetadata": {
+                    "$ref": "#/definitions/providerMetadata"
                 },
                 "descriptions": {
                     "$ref": "#/definitions/descriptions"
@@ -468,7 +469,7 @@
                 }
             },
             "required": [
-                "providerDataMeta",
+                "providerMetadata",
                 "descriptions",
                 "affected",
                 "references"
@@ -480,10 +481,11 @@
             }
         },
         "adpContainer": {
+            "description": "An object containing the vulnerability information provided by an Authorized Data Publisher (ADP). Since multiple ADPs can provide information for a CVE ID, an ADP container must indicate which ADP is the source of the information in the object.",
             "type": "object",
             "properties": {
-                "providerDataMeta": {
-                    "$ref": "#/definitions/providerDataMeta"
+                "providerMetadata": {
+                    "$ref": "#/definitions/providerMetadata"
                 },
                 "descriptions": {
                     "$ref": "#/definitions/descriptions"
@@ -491,8 +493,8 @@
                 "affected": {
                     "$ref": "#/definitions/affected"
                 },
-                "problemtypes": {
-                    "$ref": "#/definitions/problemtypes"
+                "problemTypes": {
+                    "$ref": "#/definitions/problemTypes"
                 },
                 "references": {
                     "$ref": "#/definitions/references"
@@ -523,7 +525,7 @@
                 }
             },
             "required": [
-                "providerDataMeta"
+                "providerMetadata"
             ],
             "minProperties": 2,
             "additionalProperties": {
@@ -533,45 +535,24 @@
             }
         },
         "containers": {
+            "description": "A set of structures (called containers) used to store vulnerability information related to a specific CVE ID provided by a specific organization participating in the CVE program. Each container includes information provided by a different source.\n\nAt minimum, a 'cna' container containing the vulnerability information provided by the CNA who initially assigned the CVE ID must be included.\n\nThere can only be one 'cna' container, as there can only be one assigning CNA. However, there can be multiple 'adp' containers, allowing multiple organizations participating in the CVE program to add additional information related to the vulnerability. For the most part, the 'cna' and 'adp' containers contain the same properties. The main differences are the source of the information and the 'cna' container requires the CNA include certain fields, while the 'adp' container does not.",
             "type": "object",
             "properties": {
-                "cna": {
-                    "$ref": "#/definitions/cnaContainer"
-                },
+                "cna": {"$ref": "#/definitions/cnaContainer"},
                 "adp": {
                     "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/adpContainer"
-                    },
+                    "items": {"$ref": "#/definitions/adpContainer"},
                     "minItems": 1,
                     "uniqueItems": true
                 }
             },
-            "required": [
-                "cna"
-            ],
+            "required": ["cna"],
             "additionalProperties": false
         },
         "affected": {
             "type": "object",
             "description": "CVE affects, there must be at least one defined vulnerable product either in the form of a text description (via data defined in vendors, product, version) OR a affectsCpe OR a affectsSwid",
-            "anyOf": [
-                {
-                    "required": [
-                        "vendors"
-                    ]
-                },
-                {
-                    "required": [
-                        "affectsCpe"
-                    ]
-                },
-                {
-                    "required": [
-                        "affectsSwid"
-                    ]
-                }
-            ],
+            "minProperties": 1,
             "properties": {
                 "vendors": {
                     "type": "array",
@@ -580,6 +561,7 @@
                     "uniqueItems": true,
                     "items": {
                         "type": "object",
+                        "$comment": "TODO description needed.",
                         "description": "",
                         "required": [
                             "vendorName",
@@ -589,19 +571,18 @@
                             "vendorName": {
                                 "type": "string",
                                 "description": "Name of the vendor that produced this product.",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 512
                             },
                             "products": {
                                 "description": "This is the container for affected technologies, products, hardware, etc.",
                                 "type": "array",
                                 "minItems": 1,
                                 "uniqueItems": true,
-                                "items": {
-                                    "$ref": "#/definitions/product"
+                                "items": {"$ref": "#/definitions/product"}
                                 }
                             }
                         }
-                    }
                 },
                 "affectsCpe": {
                     "type": "array",
@@ -610,19 +591,21 @@
                     "uniqueItems": true,
                     "items": {
                         "type": "object",
+                        "$comment": "TODO description needed.",
                         "description": "",
                         "properties": {},
                         "minProperties": 1
                     }
                 },
                 "affectsSwid": {
+                    "$comment": "TODO: there is no instructions on how to include an XML swid. Perhaps this should be a URI reference instead.",
                     "type": "array",
-                    "description": "",
+                    "description": "A set of SWID tags (ISO/IEC 19770-2:2015) designating which products are affected by the vulnerability. SWID tags are used to uniquely identify a piece of software.",
                     "minItems": 1,
                     "uniqueItems": true,
                     "items": {
                         "type": "object",
-                        "description": "",
+                        "description": "A SWID tag (ISO/IEC 19770-2:2015) designating a product that is affected by the vulnerability.",
                         "properties": {},
                         "minProperties": 1
                     }
@@ -637,30 +620,30 @@
             "uniqueItems": true,
             "items": {
                 "type": "object",
+                "$comment": "TODO description needed.",
                 "description": "",
                 "properties": {
-                    "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "default": "EN",
-                        "minLength": 1
-                    },
+                    "lang": {"$ref": "#/definitions/language"},
                     "value": {
                         "type": "string",
                         "description": "Plain text description of the vulnerability. Eg., [PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] allows [ATTACKER] to [IMPACT] via [VECTOR]. OR [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] [ROOT CAUSE], which allows [ATTACKER] to [IMPACT] via [VECTOR].",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     },
                     "supportingMedia": {
                         "type": "array",
                         "title": "Supporting media",
-                        "description": "Supporting media data for the description such as markdown, diagrams, .. (optional)",
-                        "uniqItems": true,
+                        "description": "Supporting media data for the description such as markdown, diagrams, .. (optional). Similar to RFC 2397 each media object has three main parts: media type, media data value, and an optional boolean flag to indicate if the media data is base64 encoded.",
+                        "uniqueItems": true,
+                        "minItems": 1,
                         "items": {
                             "type": "object",
                             "properties": {
                                 "type": {
                                     "type": "string",
                                     "title": "Media type",
+                                    "minLength": 1,
+                                    "maxLength": 255,
                                     "description": "RFC2046 compliant IANA Media type for eg., text/markdown, text/html.",
                                     "examples": [
                                         "text/markdown",
@@ -670,19 +653,17 @@
                                         "audio/mp3"
                                     ]
                                 },
-                                "encoding": {
-                                    "type": "string",
+                                "base64": {
+                                    "type": "boolean",
                                     "title": "Encoding",
-                                    "description": "Encoding used for this media eg., base64 (optional)",
-                                    "examples": [
-                                        "base64",
-                                        "utf8"
-                                    ]
+                                    "description": "If true then the value field contains the media data encoded in base64. If false then the value field contains the UTF-8 media content.",
+                                    "default": false
                                 },
                                 "value": {
                                     "type": "string",
-                                    "description": "Supporting media value",
-                                    "minLength": 1
+                                    "description": "Supporting media content, up to 16K. If base64 is true, this field stores base64 encoded data.",
+                                    "minLength": 1,
+                                    "maxLength": 16384
                                 }
                             }
                         },
@@ -703,11 +684,10 @@
             "type": "array",
             "description": "This is problem type information (e.g. CWE identifier). Must contain: At least one entry, can be text, OWASP, CWE, please note that while only one is required you can use more than one (or indeed all three) as long as they are correct). (CNA requirement: [PROBLEMTYPE])",
             "items": {
+                "$comment": "TODO: Is the description an enumeration or an example? All of these descriptions should be revisited",
                 "type": "object",
                 "description": "text, OWASP, or CWE",
-                "required": [
-                    "descriptions"
-                ],
+                "required": ["descriptions"],
                 "properties": {
                     "descriptions": {
                         "type": "array",
@@ -719,31 +699,28 @@
                                 "description"
                             ],
                             "properties": {
-                                "lang": {
-                                    "type": "string",
-                                    "description": "ISO 639-2 language code",
-                                    "minLength": 1
-                                },
+                                "lang": {"$ref": "#/definitions/language"},
                                 "description": {
                                     "type": "string",
                                     "description": "string description of problemType, or title from CWE, OWASP",
-                                    "minLength": 1
+                                    "minLength": 1,
+                                    "maxLength": 4000
                                 },
                                 "cweId": {
                                     "type": "string",
                                     "description": "CWE ID of the CWE that best describes this problemType entry",
                                     "minLength": 5,
-                                    "pattern": "^CWE-[0-9]+$"
+                                    "maxLength": 9,
+                                    "pattern": "^CWE-[1-9][0-9]+$"
                                 },
                                 "type": {
                                     "type": "string",
                                     "description": "problemtype source, text, OWASP, CWE, etc",
-                                    "minLength": 1
+                                    "minLength": 1,
+                                    "maxLength": 128
                                 },
-                                "references": {
-                                    "$ref": "#/definitions/references"
+                                "references": {"$ref": "#/definitions/references"}
                                 }
-                            }
                         },
                         "minItems": 1,
                         "uniqueItems": true
@@ -756,9 +733,7 @@
         "references": {
             "type": "array",
             "description": "This is reference data in the form of URLs or file objects (uuencoded and embedded within the JSON file, exact format to be decided, e.g. we may require a compressed format so the objects require unpacking before they are \"dangerous\").",
-            "items": {
-                "$ref": "#/definitions/reference"
-            },
+            "items": {"$ref": "#/definitions/reference"},
             "minItems": 1,
             "maxItems": 500,
             "uniqueItems": true
@@ -771,14 +746,14 @@
             "items": {
                 "type": "object",
                 "description": "This is impact type information (e.g. a text description",
-                "required": [
-                    "descriptions"
-                ],
+                "required": ["descriptions"],
                 "properties": {
                     "capecId": {
                         "type": "string",
                         "description": "CAPEC ID that best relates to this impact",
-                        "minLength": 1
+                        "minLength": 7,
+                        "maxLength": 11,
+                        "pattern": "^CAPEC-[1-9][0-9]{0,4}$"
                     },
                     "descriptions": {
                         "description": "Prose description of the impact scenario. At a minimum provide the description given by CAPEC",
@@ -797,58 +772,63 @@
                 "description": "This is impact type information (e.g. a text description, CVSSv2, CVSSv3, etc.). Must contain: At least one entry, can be text, CVSSv2, CVSSv3, others may be added",
                 "anyOf": [
                     {
-                        "required": [
-                            "cvssV3_1"
-                        ]
+                        "required": ["cvssV3_1"]
                     },
                     {
-                        "required": [
-                            "cvssV3_0"
-                        ]
+                        "required": ["cvssV3_0"]
                     },
                     {
-                        "required": [
-                            "cvssV2_0"
-                        ]
+                        "required": ["cvssV2_0"]
                     },
                     {
-                        "required": [
-                            "other"
-                        ]
+                        "required": ["other"]
                     }
                 ],
                 "properties": {
                     "format": {
                         "type": "string",
-                        "descriptions": "Name of the score format. This provides a bit future proofing. Additional properties are not prohibitied, so this will support inclusion of proprietary formats. It also provides an easy future conversion mechanism when future score formats become part of the schema. example: cvssV4_4, format = 'cvssV4_4', other = cvssV4_4 json object. In the future the other properties can be converted to score properties when they become part of the schema.",
-                        "minLength": 1
+                        "description": "Name of the score format. This provides a bit future proofing. Additional properties are not prohibitied, so this will support inclusion of proprietary formats. It also provides an easy future conversion mechanism when future score formats become part of the schema. example: cvssV4_4, format = 'cvssV4_4', other = cvssV4_4 json object. In the future the other properties can be converted to score properties when they become part of the schema.",
+                        "minLength": 1,
+                        "maxLength": 64
                     },
                     "scenario": {
-                        "type": "string",
-                        "default": "GENERAL",
-                        "description": "Description of the scenario this metrics object applies to. If no specific scenarion is given, GENERAL is used as the default and applies when no more specific metric matches.",
-                        "minLength": 1
+                        "type": "array",
+                        "description": "Description of the scenario this metrics object applies to. If no specific scenario is given, GENERAL is used as the default and applies when no more specific metric matches.",
+                        "minItems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                            "properties": {
+                                "lang": {"$ref": "#/definitions/language"},
+                                "value": {
+                                    "type": "string",
+                                    "default": "GENERAL",
+                                    "description": "Description of the scenario this metrics object applies to. If no specific scenario is given, GENERAL is used as the default and applies when no more specific metric matches.",
+                                    "minLength": 1,
+                                    "maxLength": 4000
+                                }
+                            },
+                            "required": [
+                                "lang",
+                                "value"
+                            ]
+                        }
                     },
-                    "cvssV3_1": {
-                        "$ref": "file:cvss-v3.1.json"
-                    },
-                    "cvssV3_0": {
-                        "$ref": "file:cvss-v3.0.json"
-                    },
-                    "cvssV2_0": {
-                        "$ref": "file:cvss-v2.0.json"
-                    },
+                    "cvssV3_1": {"$ref": "file:imports/cvss/cvss-v3.1.json"},
+                    "cvssV3_0": {"$ref": "file:imports/cvss/cvss-v3.0.json"},
+                    "cvssV2_0": {"$ref": "file:imports/cvss/cvss-v2.0.json"},
                     "other": {
                         "type": "object",
-                        "description": "non-standard impact description, may be prose or JSON block",
+                        "description": "a non-standard impact description, may be prose or JSON block",
                         "required": [
                             "type",
                             "content"
                         ],
                         "properties": {
                             "type": {
+                                "$comment": "TODO: description needed",
                                 "type": "string",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 128
                             },
                             "content": {
                                 "type": "object",
@@ -868,14 +848,14 @@
             "items": {
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "$ref": "#/definitions/language",
+                        "description": "The language used when describing the configuration. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code."
                     },
                     "value": {
                         "description": "Configurations required for exploiting this vulnerability.",
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -892,13 +872,14 @@
             "items": {
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "description": "The language used when describing the workaround. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code.",
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
+                        "description": "A description of how to work around or mitigate the vulnerability.",
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -915,13 +896,14 @@
             "items": {
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "description": "The language used when describing the exploit. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code.",
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
+                        "description": "A description of how to exploit the vulnerability.",
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -944,17 +926,18 @@
                 ],
                 "properties": {
                     "time": {
+                        "description": "Timestamp representing when the event in the timeline occurred. The timestamp format is based on RFC3339 and ISO ISO8601, with an optional timezone. yyyy-MM-ddTHH:mm:ssZZZZ - if the timezone offset is not given, GMT (0000) is assumed.",
                         "$ref": "#/definitions/timestamp"
                     },
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "description": "The language used in the description of the event. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code.",
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
-                        "description": "Description of event",
+                        "description": "A summary of the event.",
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 }
             }
@@ -968,13 +951,13 @@
                 "type": "object",
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "description": "The language used when describing the credits. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code.",
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -985,7 +968,7 @@
         },
         "source": {
             "type": "object",
-            "description": "This is the source information (who discovered it, who researched it, etc.) and optionally a chain of CNA information (e.g. the originating CNA and subsequent parent CNAs who have processed it before it arrives at the MITRE root).\n Must contain: IF this is in the root level it MUST contain a CNA_chain entry, IF this source entry is NOT in the root (e.g. it is part of a vendor statement) then it must contain at least one type of data entry.\n Mandatory in: none | Optional in: all containers",
+            "description": "This is the source information (who discovered it, who researched it, etc.) and optionally a chain of CNA information (e.g. the originating CNA and subsequent parent CNAs who have processed it before it arrives at the MITRE root).\n Must contain: IF this is in the root level it MUST contain a CNA_chain entry, IF this source entry is NOT in the root (e.g. it is part of a vendor statement) then it must contain at least one type of data entry.",
             "minProperties": 1
         },
         "taxonomyMappings": {
@@ -1051,6 +1034,13 @@
                 }
             }
         }
+        "language": {
+            "type": "string",
+            "description": "BCP 47 language code, language-region",
+            "default": "en",
+            "pattern": "^[A-Za-z]{2,4}([_-][A-Za-z]{4})?([_-]([A-Za-z]{2}|[0-9]{3}))?$"
+
+        }
     },
     "oneOf": [
         {
@@ -1058,14 +1048,11 @@
                 "dataType": {
                     "$ref": "#/definitions/dataType"
                 },
-                "dataFormat": {
-                    "$ref": "#/definitions/dataFormat"
-                },
                 "dataVersion": {
                     "$ref": "#/definitions/dataVersion"
                 },
-                "cveDataMeta": {
-                    "$ref": "#/definitions/cveDataMetaPublic"
+                "cveMetadata": {
+                    "$ref": "#/definitions/cveMetadataPublic"
                 },
                 "containers": {
                     "$ref": "#/definitions/containers"
@@ -1073,9 +1060,8 @@
             },
             "required": [
                 "dataType",
-                "dataFormat",
                 "dataVersion",
-                "cveDataMeta",
+                "cveMetadata",
                 "containers"
             ],
             "additionalProperties": false
@@ -1085,14 +1071,11 @@
                 "dataType": {
                     "$ref": "#/definitions/dataType"
                 },
-                "dataFormat": {
-                    "$ref": "#/definitions/dataFormat"
-                },
                 "dataVersion": {
                     "$ref": "#/definitions/dataVersion"
                 },
-                "cveDataMeta": {
-                    "$ref": "#/definitions/cveDataMetaReserved"
+                "cveMetadata": {
+                    "$ref": "#/definitions/cveMetadataReserved"
                 },
                 "descriptions": {
                     "$ref": "#/definitions/descriptions"
@@ -1100,9 +1083,8 @@
             },
             "required": [
                 "dataType",
-                "dataFormat",
                 "dataVersion",
-                "cveDataMeta"
+                "cveMetadata"
             ],
             "additionalProperties": false
         },
@@ -1111,14 +1093,11 @@
                 "dataType": {
                     "$ref": "#/definitions/dataType"
                 },
-                "dataFormat": {
-                    "$ref": "#/definitions/dataFormat"
-                },
                 "dataVersion": {
                     "$ref": "#/definitions/dataVersion"
                 },
-                "cveDataMeta": {
-                    "$ref": "#/definitions/cveDataMetaReject"
+                "cveMetadata": {
+                    "$ref": "#/definitions/cveMetadataReject"
                 },
                 "descriptions": {
                     "$ref": "#/definitions/descriptions"
@@ -1126,9 +1105,8 @@
             },
             "required": [
                 "dataType",
-                "dataFormat",
                 "dataVersion",
-                "cveDataMeta"
+                "cveMetadata"
             ],
             "additionalProperties": false
         }


### PR DESCRIPTION
General taxonomy object used to map CVEs to other taxonomies, like ATT&CK.  Approved by QWG on 1/21/2021.

Example JSON:
“taxonomyMappings”: [
  {
    “taxonomyName”: “ATT&CK”,
    “taxonomyVersion”: “7”,
    “taxonomyRelations”: [
      {
        “taxonomyId”: “T1068”,
        “relationshipName”: "Parent Tactic",
        “relationshipValue”: “TA0004”
      },
      {
        “taxonomyId”: “T1068”,
        “relationshipName”: “CVE-to-ATT&CK Primary Impact”,
        “relationshipValue”: “CVE-2019-15976”
      }
    ]
 }
]
