### PR TITLE
Applying field limits + language update

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -336,7 +336,8 @@
                 "title": {
                     "type": "string",
                     "description": "Short title - if the description is long we may want a short title to refer to",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 128
                 }
             },
             "additionalProperties": false

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -15,7 +15,8 @@
                     "maxLength": 500,
                     "minLength": 5,
                     "type": "string",
-                    "pattern": "^(ftp|http)s?://\\S+$"
+                    "format":"uri",
+                    "description":"A universal resource identifier (URI), according to RFC3986."
                 },
                 "name": {
                     "type": "string",
@@ -60,7 +61,7 @@
         },
         "cveId": {
             "type": "string",
-            "pattern": "^CVE-[0-9]{4}-[0-9]{4,}$"
+            "pattern": "^CVE-[0-9]{4}-[0-9]{4,19}$"
         },
         "orgId": {
             "type": "string",
@@ -97,7 +98,8 @@
                 "productName": {
                     "type": "string",
                     "description": "Name of the affected product.",
-                    "minLength": 1
+                    "minLength": 1,
+                    "maxLength": 2058
                 },
                 "modules": {
                     "type": "array",
@@ -106,7 +108,8 @@
                     "items": {
                         "type": "string",
                         "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "programFiles": {
@@ -116,7 +119,8 @@
                     "items": {
                         "type": "uri",
                         "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "programRoutines": {
@@ -126,7 +130,8 @@
                     "items": {
                         "type": "string",
                         "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional).",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "collectionURL": {
@@ -134,7 +139,7 @@
                     "description": "A URL that, among the users of the software package collection, is considered the most popular starting point for accessing the collection (optional).",
                     "maxLength": 500,
                     "minLength": 5,
-                    "pattern": "^(ftp|http)s?://\\S+$",
+                    "format": "uri"
                     "examples": [
                         "https://access.redhat.com/downloads/content/package-browser",
                         "https://addons.mozilla.org",
@@ -216,12 +221,14 @@
                             "versionGroup": {
                                 "type": "string",
                                 "description": "A string that represents a version branch, group, or a major version (e.g. 10.0, 3.1.*) where all version values are typically sequential or versionAffected comparisons are meaningful (optional).",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 1024
                             },
                             "versionValue": {
                                 "type": "string",
                                 "description": "The version name/value (e.g. 10.0.1, 3.1.2, \"IceHouse\")",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 1024
                             },
                             "versionAffected": {
                                 "type": "string",
@@ -589,7 +596,8 @@
                             "vendorName": {
                                 "type": "string",
                                 "description": "Name of the vendor that produced this product.",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 512
                             },
                             "products": {
                                 "description": "This is the container for affected technologies, products, hardware, etc.",
@@ -640,27 +648,28 @@
                 "description": "",
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "default": "EN",
-                        "minLength": 1
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "type": "string",
                         "description": "Plain text description of the vulnerability. Eg., [PROBLEMTYPE] in [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] allows [ATTACKER] to [IMPACT] via [VECTOR]. OR [COMPONENT] in [VENDOR] [PRODUCT] [VERSION] [ROOT CAUSE], which allows [ATTACKER] to [IMPACT] via [VECTOR].",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     },
                     "supportingMedia": {
                         "type": "array",
                         "title": "Supporting media",
                         "description": "Supporting media data for the description such as markdown, diagrams, .. (optional)",
                         "uniqItems": true,
+                        "minItems": 1,
                         "items": {
                             "type": "object",
                             "properties": {
                                 "type": {
                                     "type": "string",
                                     "title": "Media type",
+                                    "minLength": 1,
+                                    "maxLength": 255,
                                     "description": "RFC2046 compliant IANA Media type for eg., text/markdown, text/html.",
                                     "examples": [
                                         "text/markdown",
@@ -668,21 +677,23 @@
                                         "image/png",
                                         "image/svg",
                                         "audio/mp3"
-                                    ]
+                                    ],
+                                    "minLenth": 1
                                 },
                                 "encoding": {
                                     "type": "string",
                                     "title": "Encoding",
                                     "description": "Encoding used for this media eg., base64 (optional)",
-                                    "examples": [
+                                    "enum": [
                                         "base64",
                                         "utf8"
                                     ]
                                 },
                                 "value": {
                                     "type": "string",
-                                    "description": "Supporting media value",
-                                    "minLength": 1
+                                    "description": "Supporting media value, up to 16K",
+                                    "minLength": 1,
+                                    "maxLength": 16384
                                 }
                             }
                         },
@@ -720,25 +731,26 @@
                             ],
                             "properties": {
                                 "lang": {
-                                    "type": "string",
-                                    "description": "ISO 639-2 language code",
-                                    "minLength": 1
+                                    "$ref": "#/definitions/language"
                                 },
                                 "description": {
                                     "type": "string",
                                     "description": "string description of problemType, or title from CWE, OWASP",
-                                    "minLength": 1
+                                    "minLength": 1,
+                                    "maxLength": 4000
                                 },
                                 "cweId": {
                                     "type": "string",
                                     "description": "CWE ID of the CWE that best describes this problemType entry",
                                     "minLength": 5,
+                                    "maxLength": 9,
                                     "pattern": "^CWE-[0-9]+$"
                                 },
                                 "type": {
                                     "type": "string",
                                     "description": "problemtype source, text, OWASP, CWE, etc",
-                                    "minLength": 1
+                                    "minLength": 1,
+                                    "maxLength": 128
                                 },
                                 "references": {
                                     "$ref": "#/definitions/references"
@@ -778,7 +790,8 @@
                     "capecId": {
                         "type": "string",
                         "description": "CAPEC ID that best relates to this impact",
-                        "minLength": 1
+                        "minLength": 7,
+                        "maxLength": 11
                     },
                     "descriptions": {
                         "description": "Prose description of the impact scenario. At a minimum provide the description given by CAPEC",
@@ -821,13 +834,32 @@
                     "format": {
                         "type": "string",
                         "descriptions": "Name of the score format. This provides a bit future proofing. Additional properties are not prohibitied, so this will support inclusion of proprietary formats. It also provides an easy future conversion mechanism when future score formats become part of the schema. example: cvssV4_4, format = 'cvssV4_4', other = cvssV4_4 json object. In the future the other properties can be converted to score properties when they become part of the schema.",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLenght": 64
                     },
                     "scenario": {
-                        "type": "string",
-                        "default": "GENERAL",
+                        "type": "array",
                         "description": "Description of the scenario this metrics object applies to. If no specific scenarion is given, GENERAL is used as the default and applies when no more specific metric matches.",
-                        "minLength": 1
+                        "minItems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                            "properties": {
+                                "lang": {
+                                    "$ref": "#/definitions/language"
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "default": "GENERAL",
+                                    "description": "Description of the scenario this metrics object applies to. If no specific scenarion is given, GENERAL is used as the default and applies when no more specific metric matches.",
+                                    "minLength": 1,
+                                    "maxLenth": 4000
+                                }
+                            },
+                            "required": [
+                                "lang",
+                                "value"
+                            ]
+                        }
                     },
                     "cvssV3_1": {
                         "$ref": "file:cvss-v3.1.json"
@@ -848,7 +880,8 @@
                         "properties": {
                             "type": {
                                 "type": "string",
-                                "minLength": 1
+                                "minLength": 1,
+                                "maxLength": 128
                             },
                             "content": {
                                 "type": "object",
@@ -868,14 +901,13 @@
             "items": {
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "description": "Configurations required for exploiting this vulnerability.",
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -892,13 +924,12 @@
             "items": {
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -915,13 +946,12 @@
             "items": {
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -947,14 +977,13 @@
                         "$ref": "#/definitions/timestamp"
                     },
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "description": "Description of event",
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 }
             }
@@ -968,13 +997,12 @@
                 "type": "object",
                 "properties": {
                     "lang": {
-                        "type": "string",
-                        "description": "ISO 639-2 language code",
-                        "minLength": 1
+                        "$ref": "#/definitions/language"
                     },
                     "value": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "maxLength": 4000
                     }
                 },
                 "required": [
@@ -985,8 +1013,15 @@
         },
         "source": {
             "type": "object",
-            "description": "This is the source information (who discovered it, who researched it, etc.) and optionally a chain of CNA information (e.g. the originating CNA and subsequent parent CNAs who have processed it before it arrives at the MITRE root).\n Must contain: IF this is in the root level it MUST contain a CNA_chain entry, IF this source entry is NOT in the root (e.g. it is part of a vendor statement) then it must contain at least one type of data entry.\n Mandatory in: none | Optional in: all containers",
+            "description": "This is the source information (who discovered it, who researched it, etc.) and optionally a chain of CNA information (e.g. the originating CNA and subsequent parent CNAs who have processed it before it arrives at the MITRE root).\n Must contain: IF this is in the root level it MUST contain a CNA_chain entry, IF this source entry is NOT in the root (e.g. it is part of a vendor statement) then it must contain at least one type of data entry.",
             "minProperties": 1
+        },
+        "language": {
+            "type": "string",
+            "description": "BCP 47 language code",
+            "default": "en",
+            "minLength": 1,
+            "maxLength": 36
         }
     },
     "oneOf": [

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -740,7 +740,7 @@
                                     "description": "CWE ID of the CWE that best describes this problemType entry",
                                     "minLength": 5,
                                     "maxLength": 9,
-                                    "pattern": "^CWE-[0-9]+$"
+                                    "pattern": "^CWE-[1-9][0-9]+$"
                                 },
                                 "type": {
                                     "type": "string",

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -12,8 +12,6 @@
             ],
             "properties": {
                 "url": {
-                    "maxLength": 500,
-                    "minLength": 5,
                     "type": "string",
                     "format":"uri",
                     "description":"A universal resource identifier (URI), according to RFC3986."
@@ -117,10 +115,9 @@
                     "description": "A list of the affected source code files (optional)",
                     "uniqueItems": true,
                     "items": {
-                        "type": "uri",
-                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
-                        "minLength": 1,
-                        "maxLength": 4000
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional)."
                     }
                 },
                 "programRoutines": {
@@ -137,8 +134,6 @@
                 "collectionURL": {
                     "type": "string",
                     "description": "A URL that, among the users of the software package collection, is considered the most popular starting point for accessing the collection (optional).",
-                    "maxLength": 500,
-                    "minLength": 5,
                     "format": "uri"
                     "examples": [
                         "https://access.redhat.com/downloads/content/package-browser",
@@ -792,7 +787,8 @@
                         "type": "string",
                         "description": "CAPEC ID that best relates to this impact",
                         "minLength": 7,
-                        "maxLength": 11
+                        "maxLength": 11,
+                        "pattern": "^CAPEC-[1-9][0-9]{0,4}$"
                     },
                     "descriptions": {
                         "description": "Prose description of the impact scenario. At a minimum provide the description given by CAPEC",
@@ -1019,10 +1015,9 @@
         },
         "language": {
             "type": "string",
-            "description": "BCP 47 language code",
+            "description": "BCP 47 language code, languange-region",
             "default": "en",
-            "minLength": 1,
-            "maxLength": 36
+            "pattern":"^[[:alpha:]]{2,3}(?:$|-[[:alnum:]]{2,3}$)"
         }
     },
     "oneOf": [


### PR DESCRIPTION
Changed language tags to BCP 47
moved lang to definition/language
description type fields set maxLength: 4000

supportingMedia
    RFC2046 - MIME Types
    maxlength = 255 (127+1+127)
    
CAPEC
    Length 7-11 (CAPEC-[1-99999])

Metrics/format - maxLength: 64

Metrics/scenario - made array of strings for language supportingMedia

cveDataMeta/title - set maxLength to 128 (new field in 5.0)
