### PR TITLE
#19 Improve supportingMedia object

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -659,7 +659,7 @@
                     "supportingMedia": {
                         "type": "array",
                         "title": "Supporting media",
-                        "description": "Supporting media data for the description such as markdown, diagrams, .. (optional)",
+                        "description": "Supporting media data for the description such as markdown, diagrams, .. (optional). Similar to RFC 2397 each media object has three main parts: media type, media data value, and an optional boolean flag to indicate if the media data is base64 encoded.",
                         "uniqItems": true,
                         "items": {
                             "type": "object",
@@ -676,18 +676,15 @@
                                         "audio/mp3"
                                     ]
                                 },
-                                "encoding": {
-                                    "type": "string",
+                                "base64": {
+                                    "type": "boolean",
                                     "title": "Encoding",
-                                    "description": "Encoding used for this media eg., base64 (optional)",
-                                    "examples": [
-                                        "base64",
-                                        "utf8"
-                                    ]
+                                    "description": "If true then the value field contains the media data encoded in base64. If false then the value field contains the UTF-8 media content.",
+                                    "default": false
                                 },
                                 "value": {
                                     "type": "string",
-                                    "description": "Supporting media value",
+                                    "description": "Supporting media content. If base64 is true, this field stores base64 encoded data.",
                                     "minLength": 1
                                 }
                             }

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -663,7 +663,7 @@
                         "type": "array",
                         "title": "Supporting media",
                         "description": "Supporting media data for the description such as markdown, diagrams, .. (optional). Similar to RFC 2397 each media object has three main parts: media type, media data value, and an optional boolean flag to indicate if the media data is base64 encoded.",
-                        "uniqItems": true,
+                        "uniqueItems": true,
                         "minItems": 1,
                         "items": {
                             "type": "object",


### PR DESCRIPTION
Changes for #19 
Inspired by RFC 2397 for data URI scheme https://tools.ietf.org/html/rfc2397:
Each media object has three main parts: 
(1) media type,
(2) media data value, and 
(3) an optional boolean flag to indicate if the media data is base64 encoded.

This could have been simply a list of data URIs, but it will be easier to produce. edit and consume them in a decomposed structure rather than a data URI.