### PR TITLE
Provide resolvable CVSS schema references

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -117,7 +117,8 @@
                     "items": {
                         "type": "string",
                         "format": "uri",
-                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional)."
+                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
+                        "minLength": 1
                     }
                 },
                 "programRoutines": {
@@ -501,7 +502,7 @@
                     "$ref": "#/definitions/affected"
                 },
                 "problemtypes": {
-                    "$ref": "#/definitions/problemtypes"
+                    "$ref": "#/definitions/problemTypes"
                 },
                 "references": {
                     "$ref": "#/definitions/references"
@@ -662,7 +663,7 @@
                         "type": "array",
                         "title": "Supporting media",
                         "description": "Supporting media data for the description such as markdown, diagrams, .. (optional)",
-                        "uniqItems": true,
+                        "uniqueItems": true,
                         "minItems": 1,
                         "items": {
                             "type": "object",
@@ -836,9 +837,9 @@
                 "properties": {
                     "format": {
                         "type": "string",
-                        "descriptions": "Name of the score format. This provides a bit future proofing. Additional properties are not prohibitied, so this will support inclusion of proprietary formats. It also provides an easy future conversion mechanism when future score formats become part of the schema. example: cvssV4_4, format = 'cvssV4_4', other = cvssV4_4 json object. In the future the other properties can be converted to score properties when they become part of the schema.",
+                        "description": "Name of the score format. This provides a bit future proofing. Additional properties are not prohibitied, so this will support inclusion of proprietary formats. It also provides an easy future conversion mechanism when future score formats become part of the schema. example: cvssV4_4, format = 'cvssV4_4', other = cvssV4_4 json object. In the future the other properties can be converted to score properties when they become part of the schema.",
                         "minLength": 1,
-                        "maxLenght": 64
+                        "maxLength": 64
                     },
                     "scenario": {
                         "type": "array",
@@ -865,13 +866,13 @@
                         }
                     },
                     "cvssV3_1": {
-                        "$ref": "file:cvss-v3.1.json"
+                        "$ref": "file:imports/cvss/cvss-v3.1.json"
                     },
                     "cvssV3_0": {
-                        "$ref": "file:cvss-v3.0.json"
+                        "$ref": "file:imports/cvss/cvss-v3.0.json"
                     },
                     "cvssV2_0": {
-                        "$ref": "file:cvss-v2.0.json"
+                        "$ref": "file:imports/cvss/cvss-v2.0.json"
                     },
                     "other": {
                         "type": "object",

--- a/schema/v5.0/imports/cvss/README.md
+++ b/schema/v5.0/imports/cvss/README.md
@@ -1,0 +1,1 @@
+The files in this folder are included here as a stable mirror of the CVSS JSON schemas [maintained](https://www.first.org/cvss/data-representations) by the [Forum of Incident Response and Security Teams](https://www.first.org/) (FIRST).

--- a/schema/v5.0/imports/cvss/cvss-v2.0.json
+++ b/schema/v5.0/imports/cvss/cvss-v2.0.json
@@ -1,0 +1,104 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 2.0",
+    "id": "https://www.first.org/cvss/cvss-v2.0.json?20170531",
+    "type": "object",
+    "definitions": {
+        "accessVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL" ]
+        },
+        "accessComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "MEDIUM", "LOW" ]
+        },
+        "authenticationType": {
+            "type": "string",
+            "enum": [ "MULTIPLE", "SINGLE", "NONE" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "PARTIAL", "COMPLETE" ]
+        },
+        "exploitabilityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "reportConfidenceType": {
+            "type": "string",
+            "enum": [ "UNCONFIRMED", "UNCORROBORATED", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "collateralDamagePotentialType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "LOW_MEDIUM", "MEDIUM_HIGH", "HIGH", "NOT_DEFINED" ]
+        },
+        "targetDistributionType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "2.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^((AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))/)*(AV:[NAL]|AC:[LMH]|Au:[MSN]|[CIA]:[NPC]|E:(U|POC|F|H|ND)|RL:(OF|TF|W|U|ND)|RC:(UC|UR|C|ND)|CDP:(N|L|LM|MH|H|ND)|TD:(N|L|M|H|ND)|[CIA]R:(L|M|H|ND))$"
+        },
+        "accessVector":                   { "$ref": "#/definitions/accessVectorType" },
+        "accessComplexity":               { "$ref": "#/definitions/accessComplexityType" },
+        "authentication":                 { "$ref": "#/definitions/authenticationType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "exploitability":                 { "$ref": "#/definitions/exploitabilityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/reportConfidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "collateralDamagePotential":      { "$ref": "#/definitions/collateralDamagePotentialType" },
+        "targetDistribution":             { "$ref": "#/definitions/targetDistributionType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" }
+    },
+    "required": [ "version", "vectorString", "baseScore" ]
+}

--- a/schema/v5.0/imports/cvss/cvss-v3.0.json
+++ b/schema/v5.0/imports/cvss/cvss-v3.0.json
@@ -1,0 +1,143 @@
+{
+    "license": [
+        "Copyright (c) 2017, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.0",
+    "id": "https://www.first.org/cvss/cvss-v3.0.json?20170531",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3.0/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/schema/v5.0/imports/cvss/cvss-v3.1.json
+++ b/schema/v5.0/imports/cvss/cvss-v3.1.json
@@ -1,0 +1,143 @@
+{
+    "license": [
+        "Copyright (c) 2019, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 3.1",
+    "$id": "https://www.first.org/cvss/cvss-v3.1.json?20190610",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT_NETWORK", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "REQUIRED", "NOT_DEFINED" ]
+        },
+        "scopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED" ]
+        },
+        "modifiedScopeType": {
+            "type": "string",
+            "enum": [ "UNCHANGED", "CHANGED", "NOT_DEFINED" ]
+        },
+        "ciaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "exploitCodeMaturityType": {
+            "type": "string",
+            "enum": [ "UNPROVEN", "PROOF_OF_CONCEPT", "FUNCTIONAL", "HIGH", "NOT_DEFINED" ]
+        },
+        "remediationLevelType": {
+            "type": "string",
+            "enum": [ "OFFICIAL_FIX", "TEMPORARY_FIX", "WORKAROUND", "UNAVAILABLE", "NOT_DEFINED" ]
+        },
+        "confidenceType": {
+            "type": "string",
+            "enum": [ "UNKNOWN", "REASONABLE", "CONFIRMED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "3.1" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:3.1/((AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])/)*(AV:[NALP]|AC:[LH]|PR:[UNLH]|UI:[NR]|S:[UC]|[CIA]:[NLH]|E:[XUPFH]|RL:[XOTWU]|RC:[XURC]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MPR:[XUNLH]|MUI:[XNR]|MS:[XUC]|M[CIA]:[XNLH])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "scope":                          { "$ref": "#/definitions/scopeType" },
+        "confidentialityImpact":          { "$ref": "#/definitions/ciaType" },
+        "integrityImpact":                { "$ref": "#/definitions/ciaType" },
+        "availabilityImpact":             { "$ref": "#/definitions/ciaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitCodeMaturity":            { "$ref": "#/definitions/exploitCodeMaturityType" },
+        "remediationLevel":               { "$ref": "#/definitions/remediationLevelType" },
+        "reportConfidence":               { "$ref": "#/definitions/confidenceType" },
+        "temporalScore":                  { "$ref": "#/definitions/scoreType" },
+        "temporalSeverity":               { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedScope":                  { "$ref": "#/definitions/modifiedScopeType" },
+        "modifiedConfidentialityImpact":  { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedIntegrityImpact":        { "$ref": "#/definitions/modifiedCiaType" },
+        "modifiedAvailabilityImpact":     { "$ref": "#/definitions/modifiedCiaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}


### PR DESCRIPTION
This PR updates the CVE JSON record schema in the following ways:
- Adds the CVSS 2.0, 3.0, and 3.1 JSON schemas to the repository as a stable mirror.
- Fixes a few broken keywords in the CVE record schema that were preventing it from being fully valid.

Resolves #17.