### PR TITLE
Simplifying the record header (#29)

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -141,7 +141,7 @@
                 "collectionURL": {
                     "type": "string",
                     "description": "A URL that, among the users of the software package collection, is considered the most popular starting point for accessing the collection (optional).",
-                    "format": "uri"
+                    "format": "uri",
                     "examples": [
                         "https://access.redhat.com/downloads/content/package-browser",
                         "https://addons.mozilla.org",
@@ -264,13 +264,7 @@
         "dataType": {
             "type": "string",
             "enum": [
-                "CVE"
-            ]
-        },
-        "dataFormat": {
-            "type": "string",
-            "enum": [
-                "MITRE"
+                "CVE_RECORD"
             ]
         },
         "dataVersion": {
@@ -680,8 +674,7 @@
                                         "image/png",
                                         "image/svg",
                                         "audio/mp3"
-                                    ],
-                                    "minLenth": 1
+                                    ]
                                 },
                                 "encoding": {
                                     "type": "string",
@@ -843,7 +836,7 @@
                     },
                     "scenario": {
                         "type": "array",
-                        "description": "Description of the scenario this metrics object applies to. If no specific scenarion is given, GENERAL is used as the default and applies when no more specific metric matches.",
+                        "description": "Description of the scenario this metrics object applies to. If no specific scenario is given, GENERAL is used as the default and applies when no more specific metric matches.",
                         "minItems": 1,
                         "uniqueItems": true,
                         "items": {
@@ -856,7 +849,7 @@
                                     "default": "GENERAL",
                                     "description": "Description of the scenario this metrics object applies to. If no specific scenarion is given, GENERAL is used as the default and applies when no more specific metric matches.",
                                     "minLength": 1,
-                                    "maxLenth": 4000
+                                    "maxLength": 4000
                                 }
                             },
                             "required": [
@@ -1033,9 +1026,6 @@
                 "dataType": {
                     "$ref": "#/definitions/dataType"
                 },
-                "dataFormat": {
-                    "$ref": "#/definitions/dataFormat"
-                },
                 "dataVersion": {
                     "$ref": "#/definitions/dataVersion"
                 },
@@ -1048,7 +1038,6 @@
             },
             "required": [
                 "dataType",
-                "dataFormat",
                 "dataVersion",
                 "cveDataMeta",
                 "containers"
@@ -1059,9 +1048,6 @@
             "properties": {
                 "dataType": {
                     "$ref": "#/definitions/dataType"
-                },
-                "dataFormat": {
-                    "$ref": "#/definitions/dataFormat"
                 },
                 "dataVersion": {
                     "$ref": "#/definitions/dataVersion"
@@ -1075,7 +1061,6 @@
             },
             "required": [
                 "dataType",
-                "dataFormat",
                 "dataVersion",
                 "cveDataMeta"
             ],
@@ -1085,9 +1070,6 @@
             "properties": {
                 "dataType": {
                     "$ref": "#/definitions/dataType"
-                },
-                "dataFormat": {
-                    "$ref": "#/definitions/dataFormat"
                 },
                 "dataVersion": {
                     "$ref": "#/definitions/dataVersion"
@@ -1101,7 +1083,6 @@
             },
             "required": [
                 "dataType",
-                "dataFormat",
                 "dataVersion",
                 "cveDataMeta"
             ],


### PR DESCRIPTION
Removed the `dataFormat` property and related definitions.
Changed `dataType` from `MITRE` to `CVE_RECORD`.
Cleaned up some schema validation errors from previous pulls.

Resolves #29. 