### PR TITLE
Restore valid JSON

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -141,7 +141,7 @@
                 "collectionURL": {
                     "type": "string",
                     "description": "A URL that, among the users of the software package collection, is considered the most popular starting point for accessing the collection (optional).",
-                    "format": "uri"
+                    "format": "uri",
                     "examples": [
                         "https://access.redhat.com/downloads/content/package-browser",
                         "https://addons.mozilla.org",


### PR DESCRIPTION
Fix a missing comma after collectionURL "format": "uri", which made the schema invalid JSON. This was introduced in https://github.com/CVEProject/cve-schema/commit/bdca5268b377ef79c83263bcb5e2d93c9703635e