### PR TITLE
changed replaceBy to array of CVE IDs

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -320,9 +320,13 @@
                     "description": "if known, the date/time the vulnerability was disclosed publicly."
                 },
                 "replacedBy": {
-                    "description": "a single CVE ID or list of CVE IDs (comma separated)",
-                    "type": "string",
-                    "pattern": "^(CVE-[0-9]{4}-[0-9]{4,})\\s*(,\\s*CVE-[0-9]{4}-[0-9]{4,})*$"
+                    "type": "array",
+                    "description": "an array of CVE IDs",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/cveId"
+                    }
                 },
                 "state": {
                     "description": "State of CVE - PUBLIC, RESERVED, REJECT",


### PR DESCRIPTION
Changed replaceBy to an array of CVE IDs, instead of a comma separated list.

Resolves #28.