### PR TITLE
Refactor lang pattern regex to use standard character groups

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -1014,7 +1014,7 @@
             "type": "string",
             "description": "BCP 47 language code, languange-region",
             "default": "en",
-            "pattern":"^[[:alpha:]]{2,3}(?:$|-[[:alnum:]]{2,3}$)"
+            "pattern":"^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,3})?$"
         }
     },
     "oneOf": [


### PR DESCRIPTION
Character classes such as [:alpha:] are not valid in the ECMAScript regex
flavor and their use is not recommended in the JSON schema documentation:

https://json-schema.org/understanding-json-schema/reference/regular_expressions.html