### PR TITLE
Refactor affected definition and fix invalid JSON (missing comma)

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -559,23 +559,7 @@
         "affected": {
             "type": "object",
             "description": "CVE affects, there must be at least one defined vulnerable product either in the form of a text description (via data defined in vendors, product, version) OR a affectsCpe OR a affectsSwid",
-            "anyOf": [
-                {
-                    "required": [
-                        "vendors"
-                    ]
-                },
-                {
-                    "required": [
-                        "affectsCpe"
-                    ]
-                },
-                {
-                    "required": [
-                        "affectsSwid"
-                    ]
-                }
-            ],
+            "minProperties": 1,
             "properties": {
                 "vendors": {
                     "type": "array",

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -669,7 +669,7 @@
                                 "value": {
                                     "type": "string",
                                     "description": "Supporting media content, up to 16K. If base64 is true, this field stores base64 encoded data.",
-                                    "minLength": 1
+                                    "minLength": 1,
                                     "maxLength": 16384
                                 }
                             }


### PR DESCRIPTION
The anyOf->required construction that exists in the `affected` object is not necessary because there are no other properties that are defined on the object other than those 3. Thus, this can be simply stated as `"minProperties": 1` because the intent of this is to make at least one of these 3 properties required. A useful usage of anyOf->required is demonstrated on https://github.com/CVEProject/cve-schema/blob/a7a19cc651ce2fd1a87c1182b047f591784f973f/schema/v5.0/CVE_JSON_5.0.schema#L805 because there are other properties (`format`, `scenario`) that _are not_ part of the group in which at least one is required.

Also, I fixed another missing comma from the previous merged PR causing invalid JSON: https://github.com/CVEProject/cve-schema/pull/26/commits/31bd5ae98deb520bf1d9ffa31c15036a1974f592