### PR TITLE
Add a field for Platforms

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -253,6 +253,17 @@
                                     "?>="
                                 ]
                             },
+                            "platforms": {
+                                "title": "Platforms",
+                                "description": "List of specific platforms if the versionValue and versionAffected are only relevant in the context of these platforms (optional). Platforms may include execution environments, operating systems, virtualization technolgies, hardware models, or computing architectures. Lack of this field or an empty array implies that the other fields are applicable for all relevant platforms.",
+                                "type": "array",
+                                "uniqueItems": true,
+                                "items": {
+                                    "type": "string",
+                                    "examples": ["iOS", "Android", "Windows", "macOS", "x86", "ARM", "64 bit", "Big Endian", "iPad", "Chromebook", "Docker"],
+                                    "maxLength": 1024
+                                }
+                            },
                             "references": {
                                 "$ref": "#/definitions/references"
                             }

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -238,6 +238,7 @@
                                 "title": "Platforms",
                                 "description": "List of specific platforms if the versionValue and versionAffected are only relevant in the context of these platforms (optional). Platforms may include execution environments, operating systems, virtualization technolgies, hardware models, or computing architectures. Lack of this field or an empty array implies that the other fields are applicable for all relevant platforms.",
                                 "type": "array",
+                                "minItems": 1,
                                 "uniqueItems": true,
                                 "items": {
                                     "type": "string",


### PR DESCRIPTION
Helps encode descriptions of the type "vulnerability in xyz software on Windows, Android and Linux" or "Vulnerability in libABC on 64 bit architecture machines"..