### PR TITLE
Pluralize array names where appropriate. Left replacedBy alone.

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -428,19 +428,19 @@
                 "metrics": {
                     "$ref": "#/definitions/metrics"
                 },
-                "configuration": {
+                "configurations": {
                     "$ref": "#/definitions/configurations"
                 },
-                "workaround": {
+                "workarounds": {
                     "$ref": "#/definitions/workarounds"
                 },
-                "exploit": {
+                "exploits": {
                     "$ref": "#/definitions/exploits"
                 },
                 "timeline": {
                     "$ref": "#/definitions/timeline"
                 },
-                "credit": {
+                "credits": {
                     "$ref": "#/definitions/credits"
                 },
                 "source": {
@@ -484,19 +484,19 @@
                 "metrics": {
                     "$ref": "#/definitions/metrics"
                 },
-                "configuration": {
+                "configurations": {
                     "$ref": "#/definitions/configurations"
                 },
-                "workaround": {
+                "workarounds": {
                     "$ref": "#/definitions/workarounds"
                 },
-                "exploit": {
+                "exploits": {
                     "$ref": "#/definitions/exploits"
                 },
                 "timeline": {
                     "$ref": "#/definitions/timeline"
                 },
-                "credit": {
+                "credits": {
                     "$ref": "#/definitions/credits"
                 },
                 "source": {
@@ -530,7 +530,7 @@
         },
         "affected": {
             "type": "object",
-            "description": "CVE affects, there must be at least one defined vulnerable product either in the form of a text description (via data defined in vendors, product, version) OR a affectsCpe OR a affectsSwid",
+            "description": "CVE affects, there must be at least one defined vulnerable product either in the form of a text description (via data defined in vendors, product, version) OR a affectsCpes OR a affectsSwids",
             "minProperties": 1,
             "properties": {
                 "vendors": {
@@ -563,7 +563,7 @@
                             }
                         }
                 },
-                "affectsCpe": {
+                "affectsCpes": {
                     "type": "array",
                     "description": "Affected products defined by CPE. This is an array of CPE values (vulnerable and not), we use an array so that we can make multiple statements about the same version and they are separate (if we used a JSON object we'd essentially be keying on the CPE name and they would have to overlap). Also this allows things like cveDataVersion or cveDescription to be applied directly to the product entry. This also allows more complex statements such as \"Product X between versions 10.2 and 10.8\" to be put in a machine-readable format. As well since multiple statements can be used multiple branches of the same product can be defined here.",
                     "minItems": 1,
@@ -576,7 +576,7 @@
                         "minProperties": 1
                     }
                 },
-                "affectsSwid": {
+                "affectsSwids": {
                     "$comment": "TODO: there is no instructions on how to include an XML swid. Perhaps this should be a URI reference instead.",
                     "type": "array",
                     "description": "A set of SWID tags (ISO/IEC 19770-2:2015) designating which products are affected by the vulnerability. SWID tags are used to uniquely identify a piece of software.",
@@ -770,9 +770,9 @@
                         "minLength": 1,
                         "maxLength": 64
                     },
-                    "scenario": {
+                    "scenarios": {
                         "type": "array",
-                        "description": "Description of the scenario this metrics object applies to. If no specific scenario is given, GENERAL is used as the default and applies when no more specific metric matches.",
+                        "description": "Description of the scenarios this metrics object applies to. If no specific scenario is given, GENERAL is used as the default and applies when no more specific metric matches.",
                         "minItems": 1,
                         "uniqueItems": true,
                         "items": {


### PR DESCRIPTION
It also seemed appropriate to leave `supportingMedia` and `timeline` as is. Resolves #47