### PR TITLE
Use correct value for assigner field so example validates

### DIFF
--- a/schema/v5.0/docs/basic-example.json
+++ b/schema/v5.0/docs/basic-example.json
@@ -3,7 +3,8 @@
     "dataVersion": "5.0",
     "cveMetadata": {
         "id": "CVE-2015-3000",
-        "assigner": "cve@mitre.org",
+        "assigner": "9a527a5d-c98f-4910-8fa2-f6a927fa3ce3",
+        "assignerShortName": "mitre",
         "state": "PUBLIC"
     },
     "containers": {


### PR DESCRIPTION
`assigner` requires type `#/definitions/orgId`.