### PR TITLE
schema/v5.0: flatten affected into array of products

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -81,56 +81,32 @@
         "product": {
             "type": "object",
             "description": "Provides information about the set of products and services affected by this vulnerability.",
-            "required": [
-                "productName",
-                "versions"
+            "allOf": [
+                {
+                    "oneOf": [
+                        {"required": ["vendor", "product"]},
+                        {"required": ["collectionURL", "packageName"]}
+                    ]
+                },
+                {
+                    "required": ["versions"]
+                }
             ],
             "properties": {
-                "productName": {
+                "vendor": {
+                    "type": "string",
+                    "description": "Name of the organization, project, community, individual, or user that created or maintains this product or hosted service. Can be 'N/A' if none of those apply. When collectionURL and packageName are used, this field may optionally represent the user or account within the package collection associated with the package.",
+                    "minLength": 1,
+                    "maxLength": 512
+                },
+                "product": {
                     "type": "string",
                     "description": "Name of the affected product.",
                     "minLength": 1,
                     "maxLength": 2058
                 },
-                "modules": {
-                    "type": "array",
-                    "description": "A list of the affected components, features, modules, sub-components, sub-products, APIs, commands, utilities, programs, or functionalities (optional)",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
-                        "minLength": 1,
-                        "maxLength": 4000
-                    }
-                },
-                "programFiles": {
-                    "type": "array",
-                    "description": "A list of the affected source code files (optional)",
-                    "uniqueItems": true,
-                    "items": {
-                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
-                        "$ref": "#/definitions/uriType"
-                    }
-                },
-                "programRoutines": {
-                    "type": "array",
-                    "description": "A list of the affected source code functions, methods, subroutines, or procedures (optional).",
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "description": "Name of the affected source code file, function, method, subroutine, or procedure (optional).",
-                        "minLength": 1,
-                        "maxLength": 4000
-                    }
-                },
-                "packageName": {
-                    "type": "string",
-                    "description": "Name or identifier of the affected software package as used in the package collection (optional).",
-                    "minLength": 1,
-                    "maxLength": 2058
-                 },
                 "collectionURL": {
-                    "description": "A URL that, among the users of the software package collection, is considered the most popular starting point for accessing the collection (optional).",
+                    "description": "URL identifying a package collection (determines meaning of packageName).",
                     "$ref": "#/definitions/uriType",
                     "examples": [
                         "https://access.redhat.com/downloads/content/package-browser",
@@ -198,6 +174,77 @@
                         "https://wordpress.org/plugins"
                     ]
                 },
+                "packageName": {
+                    "type": "string",
+                    "description": "Name or identifier of the affected software package as used in the package collection.",
+                    "minLength": 1,
+                    "maxLength": 2058
+                 },
+                "cpes": {
+                    "type": "array",
+                    "description": "Affected products defined by CPE. This is an array of CPE values (vulnerable and not), we use an array so that we can make multiple statements about the same version and they are separate (if we used a JSON object we'd essentially be keying on the CPE name and they would have to overlap). Also this allows things like cveDataVersion or cveDescription to be applied directly to the product entry. This also allows more complex statements such as \"Product X between versions 10.2 and 10.8\" to be put in a machine-readable format. As well since multiple statements can be used multiple branches of the same product can be defined here.",
+                    "uniqueItems": true,
+                    "items": {
+                        "title": "CPE Name",
+                        "type": "string",
+                        "description":"Common Platform Enumeration (CPE) Name in either 2.2 or 2.3 format",
+                        "pattern": "([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9._\\-~%]*){0,6})|(cpe:2\\.3:[aho*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){4})",
+                        "minLength": 1,
+                        "maxLength": 2000
+                    }
+                },
+                "modules": {
+                    "type": "array",
+                    "description": "A list of the affected components, features, modules, sub-components, sub-products, APIs, commands, utilities, programs, or functionalities (optional)",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
+                        "minLength": 1,
+                        "maxLength": 4000
+                    }
+                },
+                "programFiles": {
+                    "type": "array",
+                    "description": "A list of the affected source code files (optional)",
+                    "uniqueItems": true,
+                    "items": {
+                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
+                        "$ref": "#/definitions/uriType"
+                    }
+                },
+                "programRoutines": {
+                    "type": "array",
+                    "description": "A list of the affected source code functions, methods, subroutines, or procedures (optional).",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object",
+                        "description": "Object describing program routine.",
+                        "required": [
+                            "name"
+                        ],
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the affected source code file, function, method, subroutine, or procedure.",
+                                "minLength": 1,
+                                "maxLength": 4000
+                            }
+                        }
+                    }
+                },
+                "platforms": {
+                    "title": "Platforms",
+                    "description": "List of specific platforms if the vulnerability is only relevant in the context of these platforms (optional). Platforms may include execution environments, operating systems, virtualization technolgies, hardware models, or computing architectures. Lack of this field or an empty array implies that the other fields are applicable for all relevant platforms.",
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "examples": ["iOS", "Android", "Windows", "macOS", "x86", "ARM", "64 bit", "Big Endian", "iPad", "Chromebook", "Docker"],
+                        "maxLength": 1024
+                    }
+                },
                 "versions": {
                     "type": "array",
                     "description": "Set of product versions related to the vulnerability. The versions satisfy the CNA Rules [8.1.2 requirement](https://cve.mitre.org/cve/cna/rules.html#section_8-1_cve_entry_information_requirements).",
@@ -240,18 +287,6 @@
                                     "?<=",
                                     "?>="
                                 ]
-                            },
-                            "platforms": {
-                                "title": "Platforms",
-                                "description": "List of specific platforms if the versionValue and versionAffected are only relevant in the context of these platforms (optional). Platforms may include execution environments, operating systems, virtualization technolgies, hardware models, or computing architectures. Lack of this field or an empty array implies that the other fields are applicable for all relevant platforms.",
-                                "type": "array",
-                                "minItems": 1,
-                                "uniqueItems": true,
-                                "items": {
-                                    "type": "string",
-                                    "examples": ["iOS", "Android", "Windows", "macOS", "x86", "ARM", "64 bit", "Big Endian", "iPad", "Chromebook", "Docker"],
-                                    "maxLength": 1024
-                                }
                             },
                             "references": {
                                 "$ref": "#/definitions/references"
@@ -592,52 +627,10 @@
             "additionalProperties": false
         },
         "affected": {
-            "type": "object",
-            "description": "CVE affects, there must be at least one defined vulnerable product either in the form of a text description (via data defined in vendors, product, version) OR a affectsCpe.",
-            "minProperties": 1,
-            "properties": {
-                "vendors": {
-                    "type": "array",
-                    "description": "This is the container for affected vendors, it only goes in the affects container.",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "object",
-                        "description": "a vendor that ships vulnerable product(s) and the associated vulnerable product(s) information.",
-                        "required": [
-                            "vendorName",
-                            "products"
-                        ],
-                        "properties": {
-                            "vendorName": {
-                                "type": "string",
-                                "description": "name of the organization, project, community, or individual that created or maintains this product or hosted service.",
-                                "minLength": 1,
-                                "maxLength": 512
-                            },
-                            "products": {
-                                "description": "This is the container for affected technologies, products, hardware, etc.",
-                                "type": "array",
-                                "minItems": 1,
-                                "uniqueItems": true,
-                                "items": {"$ref": "#/definitions/product"}
-                                }
-                            }
-                        }
-                },
-                "affectsCpes": {
-                    "type": "array",
-                    "description": "Affected products defined by CPE. This is an array of CPE values (vulnerable and not), we use an array so that we can make multiple statements about the same version and they are separate (if we used a JSON object we'd essentially be keying on the CPE name and they would have to overlap). Also this allows things like cveDataVersion or cveDescription to be applied directly to the product entry. This also allows more complex statements such as \"Product X between versions 10.2 and 10.8\" to be put in a machine-readable format. As well since multiple statements can be used multiple branches of the same product can be defined here.",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "object",
-                        "properties": {},
-                        "minProperties": 1
-                    }
-                }
-            },
-            "additionalProperties": false
+            "type": "array",
+            "description": "List of affected products.",
+            "minItems": 1,
+            "items": {"$ref": "#/definitions/product"}
         },
         "description": {
             "type": "object",


### PR DESCRIPTION
- Changed affected from object with array of vendor objects
  with array of products to just plain array of products.
- Added vendor string to product object.
- Renamed productName to product in product object.
- Added cpes array of string to product object,
  replacing affectsCpes inside old affected object.
- Reordered property list in product object
  to put all identifying fields first.
- Changed programRoutines to be array of objects, not array of strings.
- Defined that product object:
  - Requires a product identification, at least one of:
    - vendor and product
    - collectionURL and packageName
    - cpes
  - Also requires versions.

Based on discussion on issue #86.