### PR TITLE
Required property typo fix, description -> descriptions

### DIFF
--- a/schema/v5.0/docs/CVE_JSON_5.0_bundled.schema
+++ b/schema/v5.0/docs/CVE_JSON_5.0_bundled.schema
@@ -2093,7 +2093,7 @@
         "dataType",
         "dataVersion",
         "cveMetadata",
-        "description"
+        "descriptions"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
Bundled schema in REJECTED has a required property that isn't part of the properties object.