### PR TITLE
schema/v5.0: change programFiles from URI to string

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -223,8 +223,8 @@
                     "description": "A list of the affected source code files (optional)",
                     "uniqueItems": true,
                     "items": {
-                        "description": "Name or path or location of the affected source code file in RFC3986 compliant format (optional).",
-                        "$ref": "#/definitions/uriType"
+                        "description": "Name or path or location of the affected source code file.",
+                        "type": "string"
                     }
                 },
                 "programRoutines": {


### PR DESCRIPTION
The URI requires a scheme, when this was really meant to be a
relative path, which is not technically a URI.
Change the type to plain string.