### PR TITLE
Fix naming mismatch

### DIFF
--- a/schema/v5.0/docs/versions.md
+++ b/schema/v5.0/docs/versions.md
@@ -58,7 +58,7 @@ Most of these properties are optional.
 The only requirements are identifying information and version information.
 Identifying information may be provided by
 _either_ `vendor` and `product` (for commercial offerings)
-_or_ `collectionName` and `package` (for open-source packages).
+_or_ `collectionURL` and `packageName` (for open-source packages).
 It is fine to list both pairs, such as in the case of a
 commercial offering of packaged open-source products.
 Version information is provided by `versions` and/or `defaultStatus`, detailed in the next section.
@@ -78,7 +78,7 @@ And for an open-source package:
 	"affected": [
 		{
 			"collectionURL": "https://registry.npmjs.org",
-			"package": "left-pad",
+			"packageName": "left-pad",
 			"versions": [ ... ]
 		}
 	]


### PR DESCRIPTION
`collectionURL` and `packageName` are used in the schema and the doc, but using `collectionName` and `package` looks like a mistake.