### PR TITLE
Change CVE entry to CVE Record

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -3,7 +3,7 @@
     "$id": "https://www.cve.org/cve/v5_00/",
     "type": "object",
     "title": "CVE JSON record format",
-    "description": "cve-schema specifies the CVE JSON record format. This is the blueprint for a rich set of JSON data that can be submitted by CVE Numbering Authorities (CNAs) and Authorized Data Publishers (ADPs) to describe a CVE record. Some examples of CVE record data include CVE ID number, affected product(s), affected version(s), and public references. While those specific items are required when assigning a CVE, there are many other optional data in the schema that can be used to enrich CVE records for community benefit. Learn more about the CVE program at [the official website](https://cve.mitre.org). This CVE JSON record format is defined using JSON Schema. Learn more about JSON Schema [here](https://json-schema.org/).",
+    "description": "cve-schema specifies the CVE JSON record format. This is the blueprint for a rich set of JSON data that can be submitted by CVE Numbering Authorities (CNAs) and Authorized Data Publishers (ADPs) to describe a CVE Record. Some examples of CVE Record data include CVE ID number, affected product(s), affected version(s), and public references. While those specific items are required when assigning a CVE, there are many other optional data in the schema that can be used to enrich CVE Records for community benefit. Learn more about the CVE program at [the official website](https://cve.mitre.org). This CVE JSON record format is defined using JSON Schema. Learn more about JSON Schema [here](https://json-schema.org/).",
     "definitions": {
         "uriType": {
             "description": "A universal resource identifier (URI), according to [RFC 3986](https://tools.ietf.org/html/rfc3986).",
@@ -409,7 +409,7 @@
                 },
                 "datePublished": {
                     "$ref": "#/definitions/timestamp",
-                    "description": "The date/time the CVE record was first published in the CVE List."
+                    "description": "The date/time the CVE Record was first published in the CVE List."
                 },
                 "state": {
                     "description": "State of CVE - PUBLISHED, RESERVED, REJECTED",
@@ -483,7 +483,7 @@
                 },
                 "datePublished": {
                     "$ref": "#/definitions/timestamp",
-                    "description": "The date/time the CVE record was first published in the CVE List."
+                    "description": "The date/time the CVE Record was first published in the CVE List."
                 },
                 "dateRejected": {
                     "$ref": "#/definitions/timestamp",
@@ -536,7 +536,7 @@
             "required": ["id"]
         },
         "cnaContainer": {
-            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA). There can only be one CNA container per CVE record since there can only be one assigning CNA. The CNA container must include the required information defined in the CVE Rules, which includes a product, version, problem type, prose description, and a reference.",
+            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA). There can only be one CNA container per CVE Record since there can only be one assigning CNA. The CNA container must include the required information defined in the CVE Rules, which includes a product, version, problem type, prose description, and a reference.",
             "type": "object",
             "properties": {
                 "providerMetadata": {
@@ -972,7 +972,7 @@
                         "$ref": "#/definitions/timestamp"
                     },
                     "lang": {
-                        "description": "The language used in the description of the event. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code.",
+                        "description": "The language used in the description of the event. The language field is included so that CVE Records can support translations. The value must be a BCP 47 language code.",
                         "$ref": "#/definitions/language"
                     },
                     "value": {
@@ -993,7 +993,7 @@
                 "type": "object",
                 "properties": {
                     "lang": {
-                        "description": "The language used when describing the credits. The language field is included so that CVE records can support translations. The value must be a BCP 47 language code.",
+                        "description": "The language used when describing the credits. The language field is included so that CVE Records can support translations. The value must be a BCP 47 language code.",
                         "$ref": "#/definitions/language"
                     },
                     "value": {

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -956,7 +956,7 @@
         },
         "timeline": {
             "type": "array",
-            "description": "This is timeline information for significant events about this vulnerability or changes to CVE entry",
+            "description": "This is timeline information for significant events about this vulnerability or changes to the CVE Record",
             "minItems": 1,
             "uniqueItems": true,
             "items": {
@@ -1116,7 +1116,7 @@
         },
         "cnaTags": {
             "type": "array",
-            "description": "Tags describing the CVE entry",
+            "description": "Tags describing the CVE Record",
             "uniqueItems": true,
             "minItems": 1,
             "items": {
@@ -1132,7 +1132,7 @@
         },
         "adpTags": {
             "type": "array",
-            "description": "Tags describing the CVE entry",
+            "description": "Tags describing the CVE Record",
             "uniqueItems": true,
             "minItems": 1,
             "items": {

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -401,7 +401,7 @@
                 "serial": {
                     "type": "integer",
                     "minimum": 1,
-                    "description": "starts at 1, add 1 every time an entry is updated or changed"
+                    "description": "The system of record causes this to start at 1, and increment by 1 each time a submission from a data provider changes this CVE Record. The incremented value moves to the Rejected schema upon a PUBLISHED->REJECTED transition, and moves to the Published schema upon a REJECTED->PUBLISHED transition."
                 },
                 "dateReserved": {
                     "$ref": "#/definitions/timestamp",
@@ -475,7 +475,7 @@
                 "serial": {
                     "type": "integer",
                     "minimum": 1,
-                    "description": "starts at 1, add 1 every time an entry is updated or changed"
+                    "description": "The system of record causes this to start at 1, and increment by 1 each time a submission from a data provider changes this CVE Record. The incremented value moves to the Rejected schema upon a PUBLISHED->REJECTED transition, and moves to the Published schema upon a REJECTED->PUBLISHED transition."
                 },
                 "updated": {
                     "description": "the date/time the record was last updated",


### PR DESCRIPTION
Resolves #116. Also applies consistent capitalization for CVE Record, following the patterns currently used in https://cve.mitre.org/cve/cna/rules.html but substituting CVE Entry/Entries for CVE Record(s).