### PR TITLE
Stateful CNA container

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -348,15 +348,6 @@
                 }
             }
         },
-        "replacedBy": {
-            "type": "array",
-            "description": "Contains an array of CVE IDs that this CVE ID was rejected in favor of because the this CVE ID was assigned to the vulnerabilities",
-            "minItems": 1,
-            "uniqueItems": true,
-            "items": {
-                "$ref": "#/definitions/cveId"
-            }
-        },
         "dataType": {
             "description": "Indicates the type of information represented in the JSON instance.",
             "type": "string",
@@ -535,8 +526,8 @@
             },
             "required": ["id"]
         },
-        "cnaContainer": {
-            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA). There can only be one CNA container per CVE record since there can only be one assigning CNA. The CNA container must include the required information defined in the CVE Rules, which includes a product, version, problem type, prose description, and a reference.",
+        "cnaPublishedContainer": {
+            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA) for a published CVE ID. There can only be one CNA container per CVE record since there can only be one assigning CNA. The CNA container must include the required information defined in the CVE Rules, which includes a product, version, problem type, prose description, and a reference.",
             "type": "object",
             "properties": {
                 "providerMetadata": {
@@ -593,6 +584,54 @@
                 "descriptions",
                 "affected",
                 "references"
+            ],
+            "patternProperties": {
+                "^x_": {}
+            },
+            "additionalProperties": false
+        },
+        "cnaReservedContainer": {
+            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA) for a reserved CVE ID. There can only be one CNA container per CVE record since there can only be one assigning CNA.",
+            "type": "object",
+            "properties": {
+                "providerMetadata": {
+                    "$ref": "#/definitions/providerMetadata"
+                },
+                "descriptions": {
+                    "$ref": "#/definitions/descriptions"
+                }
+            },
+            "required": [
+                "providerMetadata"
+            ],
+            "patternProperties": {
+                "^x_": {}
+            },
+            "additionalProperties": false
+        },
+        "cnaRejectedContainer": {
+            "description": "An object containing the vulnerability information provided by a CVE Numbering Authority (CNA) for a rejected CVE ID. There can only be one CNA container per CVE record since there can only be one assigning CNA.",
+            "type": "object",
+            "properties": {
+                "providerMetadata": {
+                    "$ref": "#/definitions/providerMetadata"
+                },
+                "descriptions": {
+                    "$ref": "#/definitions/descriptions"
+                },
+                "replacedBy": {
+                    "type": "array",
+                    "description": "Contains an array of CVE IDs that this CVE ID was rejected in favor of because the this CVE ID was assigned to the vulnerabilities",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/cveId"
+                    }
+                }
+            },
+            "required": [
+                "providerMetadata",
+                "descriptions"
             ],
             "patternProperties": {
                 "^x_": {}
@@ -659,21 +698,6 @@
             "patternProperties": {
                 "^x_": {}
             },
-            "additionalProperties": false
-        },
-        "containers": {
-            "description": "A set of structures (called containers) used to store vulnerability information related to a specific CVE ID provided by a specific organization participating in the CVE program. Each container includes information provided by a different source.\n\nAt minimum, a 'cna' container containing the vulnerability information provided by the CNA who initially assigned the CVE ID must be included.\n\nThere can only be one 'cna' container, as there can only be one assigning CNA. However, there can be multiple 'adp' containers, allowing multiple organizations participating in the CVE program to add additional information related to the vulnerability. For the most part, the 'cna' and 'adp' containers contain the same properties. The main differences are the source of the information and the 'cna' container requires the CNA include certain fields, while the 'adp' container does not.",
-            "type": "object",
-            "properties": {
-                "cna": {"$ref": "#/definitions/cnaContainer"},
-                "adp": {
-                    "type": "array",
-                    "items": {"$ref": "#/definitions/adpContainer"},
-                    "minItems": 1,
-                    "uniqueItems": true
-                }
-            },
-            "required": ["cna"],
             "additionalProperties": false
         },
         "affected": {
@@ -1162,7 +1186,19 @@
                     "$ref": "#/definitions/cveMetadataPublished"
                 },
                 "containers": {
-                    "$ref": "#/definitions/containers"
+                    "description": "A set of structures (called containers) used to store vulnerability information related to a specific CVE ID provided by a specific organization participating in the CVE program. Each container includes information provided by a different source.\n\nAt minimum, a 'cna' container containing the vulnerability information provided by the CNA who initially assigned the CVE ID must be included.\n\nThere can only be one 'cna' container, as there can only be one assigning CNA. However, there can be multiple 'adp' containers, allowing multiple organizations participating in the CVE program to add additional information related to the vulnerability. For the most part, the 'cna' and 'adp' containers contain the same properties. The main differences are the source of the information and the 'cna' container requires the CNA include certain fields, while the 'adp' container does not.",
+                    "type": "object",
+                    "properties": {
+                        "cna": {"$ref": "#/definitions/cnaPublishedContainer"},
+                        "adp": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/adpContainer"},
+                            "minItems": 1,
+                            "uniqueItems": true
+                        }
+                    },
+                    "required": ["cna"],
+                    "additionalProperties": false
                 }
             },
             "required": [
@@ -1186,14 +1222,21 @@
                 "cveMetadata": {
                     "$ref": "#/definitions/cveMetadataReserved"
                 },
-                "descriptions": {
-                    "$ref": "#/definitions/descriptions"
+                "containers": {
+                    "description": "A set of structures (called containers) used to store vulnerability information related to a specific CVE ID provided by a specific organization participating in the CVE program. Each container includes information provided by a different source.\n\nAt minimum, a 'cna' container containing the vulnerability information provided by the CNA who initially assigned the CVE ID must be included.\n\nThere can only be one 'cna' container, as there can only be one assigning CNA.",
+                    "type": "object",
+                    "properties": {
+                        "cna": {"$ref": "#/definitions/cnaReservedContainer"}
+                    },
+                    "required": ["cna"],
+                    "additionalProperties": false
                 }
             },
             "required": [
                 "dataType",
                 "dataVersion",
-                "cveMetadata"
+                "cveMetadata",
+                "containers"
             ],
             "additionalProperties": false
         },
@@ -1210,18 +1253,21 @@
                 "cveMetadata": {
                     "$ref": "#/definitions/cveMetadataRejected"
                 },
-                "descriptions": {
-                    "$ref": "#/definitions/descriptions"
-                },
-                "replacedBy": {
-                    "$ref": "#/definitions/replacedBy"
+                "containers": {
+                    "description": "A set of structures (called containers) used to store vulnerability information related to a specific CVE ID provided by a specific organization participating in the CVE program. Each container includes information provided by a different source.\n\nAt minimum, a 'cna' container containing the vulnerability information provided by the CNA who initially assigned the CVE ID must be included.\n\nThere can only be one 'cna' container, as there can only be one assigning CNA.",
+                    "type": "object",
+                    "properties": {
+                        "cna": {"$ref": "#/definitions/cnaRejectedContainer"}
+                    },
+                    "required": ["cna"],
+                    "additionalProperties": false
                 }
             },
             "required": [
                 "dataType",
                 "dataVersion",
                 "cveMetadata",
-                "descriptions"
+                "containers"
             ],
             "additionalProperties": false
         }

--- a/schema/v5.0/CVE_JSON_5.0.schema
+++ b/schema/v5.0/CVE_JSON_5.0.schema
@@ -227,7 +227,7 @@
                         "description": "Name or path or location of the affected source code file.",
                         "type": "string",
                         "minLength": 1,
-                        "maxLength": 1024                        
+                        "maxLength": 1024
                     }
                 },
                 "programRoutines": {


### PR DESCRIPTION
This change moves the CVE record data for the reserved and rejected states into the CNA container to make it easier to submit CVE records using a single CNA container update in the API, and unify the CVE record information into a single entity instead.

See also REST API design discussion, from which this change stems here: https://github.com/CVEProject/cve-services/discussions/510

This also allows for future flexibility to add/remove additional attributes in the state-specific CNA container that could be used to
provide additional information on CVE reservations (e.g. more structured pre-disclosure announcements) or CVE rejections (e.g. references or timeline information).

