### PR TITLE
CnaRejectedContainer Fix

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -581,7 +581,7 @@
             },
             "required": [
                 "providerMetadata",
-                "descriptions"
+                "rejectedReasons"
             ],
             "patternProperties": {
                 "^x_": {}

--- a/schema/v5.0/docs/CVE_JSON_5.0_bundled.json
+++ b/schema/v5.0/docs/CVE_JSON_5.0_bundled.json
@@ -666,7 +666,7 @@
       },
       "required": [
         "providerMetadata",
-        "descriptions"
+        "rejectedReasons"
       ],
       "patternProperties": {
         "^x_": {}


### PR DESCRIPTION
cnaRejectedContainer lists "descriptions" as a required property, but this field was replaced by "rejectedReasons" in the listed properties. Thus records in the rejected state will always fail validation expecting a "descriptions" field that doesn't exist.