### PR TITLE
Fix incorrectly aligned body of v5 advanced example JSON

### DIFF
--- a/schema/v5.0/docs/advanced-example.json
+++ b/schema/v5.0/docs/advanced-example.json
@@ -1,310 +1,310 @@
 {
-    "dataType": "CVE_RECORD",
-    "dataVersion": "5.0",
-    "cveMetadata": {
-      "cveId": "CVE-1337-1234",
-      "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
-      "assignerShortName": "example",
-      "requesterUserId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
-      "serial": 1,
-      "state": "PUBLISHED"
-    },
-    "containers": {
-      "cna": {
-        "providerMetadata": {
-          "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
-          "shortName": "example",
-          "dateUpdated":  "2021-09-08T16:24:00.000Z"
-        },
-        "title": "Buffer overflow in Example Enterprise allows Privilege Escalation.",
-        "datePublic": "2021-09-08T16:24:00.000Z",
-        "problemTypes": [
-          {
-            "descriptions": [
-              {
-                "lang": "en",
-                "cweId": "CWE-78",
-                "description": "CWE-78 OS Command Injection",
-                "type": "CWE"
-              }
-            ]
-          }
-        ],
-        "impacts": [
-          {
-            "capecId": "CAPEC-233",
-            "descriptions": [
-              {
-                "lang": "en",
-                "value": "CAPEC-233 Privilege Escalation"
-              }
-            ]
-          }
-        ],
-        "affected": [
-          {
-            "vendor": "Example.org",
-            "product": "Example Enterprise",
-            "platforms": [
-              "Windows",
-              "MacOS",
-              "XT-4500"
-            ],
-            "collectionURL": "https://example.org/packages",
-            "packageName": "example_enterprise",
-            "repo": "git://example.org/source/example_enterprise",
-            "modules": [
-              "Web-Management-Interface"
-            ],
-            "programFiles": [
-              "example_enterprise/example.php"
-            ],
-            "programRoutines": [
-              {
-                "name": "parseFilename"
-              }
-            ],
-            "versions": [
-              {
-                "version": "1.0.0",
-                "status": "affected",
-                "lessThan": "1.0.6",
-                "versionType": "semver"
-              },
-              {
-                "version": "2.1.0",
-                "status": "unaffected",
-                "lessThan": "2.1.*",
-                "changes": [
-                  {
-                    "at": "2.1.6",
-                    "status": "affected"
-                  },
-                  {
-                    "at": "2.1.9",
-                    "status": "unaffected"
-                  }
-                ],
-                "versionType": "semver"
-              },
-              {
-                "version": "3.0.0",
-                "status": "unaffected",
-                "lessThan": "*",
-                "versionType": "semver"
-              }
-            ],
-            "defaultStatus": "unaffected"
-          }
-        ],
-        "descriptions": [
-          {
-            "lang": "en",
-            "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, macOS, and XT-4500 allows remote unauthenticated attackers to escalate privileges. This issue affects: 1.0 versions before 1.0.6, 2.1 versions from 2.16 until 2.1.9.",
-            "supportingMedia": [
-              {
-                "type": "text/html",
-                "base64": false,
-                "value": "OS Command Injection vulnerability <tt>parseFilename</tt> function of <tt>example.php</tt> in the Web Management Interface of Example.org Example Enterprise on Windows, macOS, and XT-4500 allows remote unauthenticated attackers to escalate privileges.<br><br>This issue affects:<br><ul><li>1.0 versions before 1.0.6</li><li>2.1 versions from 2.16 until 2.1.9.</li></ul>"
-              }
-            ]
-          },
-          {
-            "lang": "eo",
-            "value": "OS-komand-injekta vundebleco parseFilename funkcio de example.php en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn. Ĉi tiu afero efikas: 1.0-versioj antaŭ 1.0.6, 2.1-versioj de 2.16 ĝis 2.1.9.",
-            "supportingMedia": [
-              {
-                "type": "text/html",
-                "base64": false,
-                "value": "OS-komand-injekta vundebleco <tt>parseFilename</tt> funkcio de <tt>example.php</tt> en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn.<br><br> Ĉi tiu afero efikas:<br><ul><li>1.0-versioj antaŭ 1.0.6</li><li>2.1-versioj de 2.16 ĝis 2.1.9.</li></ul>"
-              }
-            ]
-          }          
-        ],
-        "metrics": [
-          {
-            "format": "CVSS",
-            "scenarios": [
-              {
-                "lang": "en",
-                "value": "GENERAL"
-              }
-            ],
-            "cvssV3_1": {
-              "version": "3.1",
-              "attackVector": "NETWORK",
-              "attackComplexity": "LOW",
-              "privilegesRequired": "NONE",
-              "userInteraction": "NONE",
-              "scope": "UNCHANGED",
-              "confidentialityImpact": "HIGH",
-              "integrityImpact": "HIGH",
-              "availabilityImpact": "HIGH",
-              "baseScore": 9.8,
-              "baseSeverity": "CRITICAL",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.0",
+  "cveMetadata": {
+    "cveId": "CVE-1337-1234",
+    "assignerOrgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+    "assignerShortName": "example",
+    "requesterUserId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+    "serial": 1,
+    "state": "PUBLISHED"
+  },
+  "containers": {
+    "cna": {
+      "providerMetadata": {
+        "orgId": "b3476cb9-2e3d-41a6-98d0-0f47421a65b6",
+        "shortName": "example",
+        "dateUpdated":  "2021-09-08T16:24:00.000Z"
+      },
+      "title": "Buffer overflow in Example Enterprise allows Privilege Escalation.",
+      "datePublic": "2021-09-08T16:24:00.000Z",
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "lang": "en",
+              "cweId": "CWE-78",
+              "description": "CWE-78 OS Command Injection",
+              "type": "CWE"
             }
-          },
-          {
-            "format": "CVSS",
-            "scenarios": [
-              {
-                "lang": "en",
-                "value": "If the enhanced host protection mode is turned on, this vulnerability can only be exploited to run os commands as user 'nobody'. Privilege escalation is not possible."
-              }
-            ],
-            "cvssV3_1": {
-              "version": "3.1",
-              "attackVector": "NETWORK",
-              "attackComplexity": "LOW",
-              "privilegesRequired": "NONE",
-              "userInteraction": "NONE",
-              "scope": "UNCHANGED",
-              "confidentialityImpact": "LOW",
-              "integrityImpact": "LOW",
-              "availabilityImpact": "LOW",
-              "baseScore": 7.3,
-              "baseSeverity": "HIGH",
-              "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+          ]
+        }
+      ],
+      "impacts": [
+        {
+          "capecId": "CAPEC-233",
+          "descriptions": [
+            {
+              "lang": "en",
+              "value": "CAPEC-233 Privilege Escalation"
             }
-          }
-        ],
-        "solutions": [
-          {
-            "lang": "en",
-            "value": "This issue is fixed in 1.0.6, 2.1.9, and 3.0.0 and all later versions.",
-            "supportingMedia": [
-              {
-                "type": "text/html",
-                "base64": false,
-                "value": "This issue is fixed in 1.0.6, 2.1.9, and 3.0.0 and all later versions."
-              }
-            ]
-          }
-        ],
-        "workarounds": [
-          {
-            "lang": "en",
-            "value": "Disable the web management interface with the command\n> service disable webmgmt",
-            "supportingMedia": [
-              {
-                "type": "text/html",
-                "base64": false,
-                "value": "Disable the web management interface with the command<br><pre>&gt; <b>service disable webmgmt</b></pre>"
-              }
-            ]
-          }
-        ],
-        "configurations": [
-          {
-            "lang": "en",
-            "value": "Web management interface should be enabled.\n> service status webmgmt\nwebmgmt running",
-            "supportingMedia": [
-              {
-                "type": "text/html",
-                "base64": false,
-                "value": "Web management interface should be enabled.<br><pre>&gt; <b>service status webmgmt</b><br>webmgmt running</pre>"
-              }
-            ]
-          }
-        ],
-        "exploits": [
-          {
-            "lang": "en",
-            "value": "Example.org is not aware of any malicious exploitation of the issue however exploits targeting this issue are publicly available.",
-            "supportingMedia": [
-              {
-                "type": "text/html",
-                "base64": false,
-                "value": "Example.org is not aware of any malicious exploitation of the issue however exploits targeting this issue are publicly available."
-              }
-            ]
-          }
-        ],
-        "timeline": [
-          {
-            "time": "2001-09-01T07:31:00.000Z",
-            "lang": "en",
-            "value": "Issue discovered by Alice using Acme Autofuzz"
-          },
-          {
-            "time": "2021-09-02T16:36:00.000Z",
-            "lang": "en",
-            "value": "Confirmed by Bob"
-          },
-          {
-            "time": "2021-09-07T16:37:00.000Z",
-            "lang": "en",
-            "value": "Fixes released"
-          }
-        ],
-        "credits": [
-          {
-            "lang": "en",
-            "value": "Alice",
-            "type": "finder"
-          },
-          {
-            "lang": "en",
-            "value": "Bob",
-            "type": "analyst"
-          },
-          {
-            "lang": "en",
-            "value": "Acme Autofuzz",
-            "type": "tool"
-          }
-        ],
-        "references": [
-          {
-            "url": "https://example.org/ESA-22-11-CVE-1337-1234",
-            "name": "ESA-22-11",
-            "tags": [
-              "vendor-advisory"
-            ]
-          },
-          {
-            "url": "https://example.com/blog/alice/pwning_example_enterprise",
-            "name": "Pwning Example Enterprise",
-            "tags": [
-              "technical-description",
-              "third-party-advisory"
-            ]
-          },
-          {
-            "url": "https://example.org/bugs/EXAMPLE-1234",
-            "name": "EXAMPLE-1234",
-            "tags": [
-              "issue-tracking"
-            ]
-          },
-          {
-            "url": "https://example.org/ExampleEnterprise",
-            "tags": [
-              "product"
-            ]
-          }
-        ],
-        "source": {
-          "defects": [
-            "EXAMPLE-1234"
+          ]
+        }
+      ],
+      "affected": [
+        {
+          "vendor": "Example.org",
+          "product": "Example Enterprise",
+          "platforms": [
+            "Windows",
+            "MacOS",
+            "XT-4500"
           ],
-          "advisory": "ESA-22-11",
-          "discovery": "EXTERNAL"
+          "collectionURL": "https://example.org/packages",
+          "packageName": "example_enterprise",
+          "repo": "git://example.org/source/example_enterprise",
+          "modules": [
+            "Web-Management-Interface"
+          ],
+          "programFiles": [
+            "example_enterprise/example.php"
+          ],
+          "programRoutines": [
+            {
+              "name": "parseFilename"
+            }
+          ],
+          "versions": [
+            {
+              "version": "1.0.0",
+              "status": "affected",
+              "lessThan": "1.0.6",
+              "versionType": "semver"
+            },
+            {
+              "version": "2.1.0",
+              "status": "unaffected",
+              "lessThan": "2.1.*",
+              "changes": [
+                {
+                  "at": "2.1.6",
+                  "status": "affected"
+                },
+                {
+                  "at": "2.1.9",
+                  "status": "unaffected"
+                }
+              ],
+              "versionType": "semver"
+            },
+            {
+              "version": "3.0.0",
+              "status": "unaffected",
+              "lessThan": "*",
+              "versionType": "semver"
+            }
+          ],
+          "defaultStatus": "unaffected"
+        }
+      ],
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "OS Command Injection vulnerability parseFilename function of example.php in the Web Management Interface of Example.org Example Enterprise on Windows, macOS, and XT-4500 allows remote unauthenticated attackers to escalate privileges. This issue affects: 1.0 versions before 1.0.6, 2.1 versions from 2.16 until 2.1.9.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "OS Command Injection vulnerability <tt>parseFilename</tt> function of <tt>example.php</tt> in the Web Management Interface of Example.org Example Enterprise on Windows, macOS, and XT-4500 allows remote unauthenticated attackers to escalate privileges.<br><br>This issue affects:<br><ul><li>1.0 versions before 1.0.6</li><li>2.1 versions from 2.16 until 2.1.9.</li></ul>"
+            }
+          ]
         },
-        "taxonomyMappings": [
-          {
-            "taxonomyName": "ATT&CK",
-            "taxonomyVersion": "v9",
-            "taxonomyRelations": [
-              {
-                "taxonomyId": "T1190",
-                "relationshipName": "mitigated by",
-                "relationshipValue": "M1048"
-              }
-            ]
+        {
+          "lang": "eo",
+          "value": "OS-komand-injekta vundebleco parseFilename funkcio de example.php en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn. Ĉi tiu afero efikas: 1.0-versioj antaŭ 1.0.6, 2.1-versioj de 2.16 ĝis 2.1.9.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "OS-komand-injekta vundebleco <tt>parseFilename</tt> funkcio de <tt>example.php</tt> en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn.<br><br> Ĉi tiu afero efikas:<br><ul><li>1.0-versioj antaŭ 1.0.6</li><li>2.1-versioj de 2.16 ĝis 2.1.9.</li></ul>"
+            }
+          ]
+        }
+      ],
+      "metrics": [
+        {
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "GENERAL"
+            }
+          ],
+          "cvssV3_1": {
+            "version": "3.1",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "availabilityImpact": "HIGH",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
           }
-        ]
-      }
+        },
+        {
+          "format": "CVSS",
+          "scenarios": [
+            {
+              "lang": "en",
+              "value": "If the enhanced host protection mode is turned on, this vulnerability can only be exploited to run os commands as user 'nobody'. Privilege escalation is not possible."
+            }
+          ],
+          "cvssV3_1": {
+            "version": "3.1",
+            "attackVector": "NETWORK",
+            "attackComplexity": "LOW",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "scope": "UNCHANGED",
+            "confidentialityImpact": "LOW",
+            "integrityImpact": "LOW",
+            "availabilityImpact": "LOW",
+            "baseScore": 7.3,
+            "baseSeverity": "HIGH",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+          }
+        }
+      ],
+      "solutions": [
+        {
+          "lang": "en",
+          "value": "This issue is fixed in 1.0.6, 2.1.9, and 3.0.0 and all later versions.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "This issue is fixed in 1.0.6, 2.1.9, and 3.0.0 and all later versions."
+            }
+          ]
+        }
+      ],
+      "workarounds": [
+        {
+          "lang": "en",
+          "value": "Disable the web management interface with the command\n> service disable webmgmt",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "Disable the web management interface with the command<br><pre>&gt; <b>service disable webmgmt</b></pre>"
+            }
+          ]
+        }
+      ],
+      "configurations": [
+        {
+          "lang": "en",
+          "value": "Web management interface should be enabled.\n> service status webmgmt\nwebmgmt running",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "Web management interface should be enabled.<br><pre>&gt; <b>service status webmgmt</b><br>webmgmt running</pre>"
+            }
+          ]
+        }
+      ],
+      "exploits": [
+        {
+          "lang": "en",
+          "value": "Example.org is not aware of any malicious exploitation of the issue however exploits targeting this issue are publicly available.",
+          "supportingMedia": [
+            {
+              "type": "text/html",
+              "base64": false,
+              "value": "Example.org is not aware of any malicious exploitation of the issue however exploits targeting this issue are publicly available."
+            }
+          ]
+        }
+      ],
+      "timeline": [
+        {
+          "time": "2001-09-01T07:31:00.000Z",
+          "lang": "en",
+          "value": "Issue discovered by Alice using Acme Autofuzz"
+        },
+        {
+          "time": "2021-09-02T16:36:00.000Z",
+          "lang": "en",
+          "value": "Confirmed by Bob"
+        },
+        {
+          "time": "2021-09-07T16:37:00.000Z",
+          "lang": "en",
+          "value": "Fixes released"
+        }
+      ],
+      "credits": [
+        {
+          "lang": "en",
+          "value": "Alice",
+          "type": "finder"
+        },
+        {
+          "lang": "en",
+          "value": "Bob",
+          "type": "analyst"
+        },
+        {
+          "lang": "en",
+          "value": "Acme Autofuzz",
+          "type": "tool"
+        }
+      ],
+      "references": [
+        {
+          "url": "https://example.org/ESA-22-11-CVE-1337-1234",
+          "name": "ESA-22-11",
+          "tags": [
+            "vendor-advisory"
+          ]
+        },
+        {
+          "url": "https://example.com/blog/alice/pwning_example_enterprise",
+          "name": "Pwning Example Enterprise",
+          "tags": [
+            "technical-description",
+            "third-party-advisory"
+          ]
+        },
+        {
+          "url": "https://example.org/bugs/EXAMPLE-1234",
+          "name": "EXAMPLE-1234",
+          "tags": [
+            "issue-tracking"
+          ]
+        },
+        {
+          "url": "https://example.org/ExampleEnterprise",
+          "tags": [
+            "product"
+          ]
+        }
+      ],
+      "source": {
+        "defects": [
+          "EXAMPLE-1234"
+        ],
+        "advisory": "ESA-22-11",
+        "discovery": "EXTERNAL"
+      },
+      "taxonomyMappings": [
+        {
+          "taxonomyName": "ATT&CK",
+          "taxonomyVersion": "v9",
+          "taxonomyRelations": [
+            {
+              "taxonomyId": "T1190",
+              "relationshipName": "mitigated by",
+              "relationshipValue": "M1048"
+            }
+          ]
+        }
+      ]
     }
   }
+}


### PR DESCRIPTION
This produces an invalid JSON that fails schema validation. Removing the leading two spaces from all but the first line solves the issue.