### PR TITLE
Fix timestamp syntax for issue 210

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -76,7 +76,7 @@
         "timestamp": {
             "type": "string",
             "format": "date-time",
-            "description": "Date/time format based on RFC3339 and ISO ISO8601, with an optional timezone in the format 'yyyy-MM-ddTHH:mm:ssZZZZ'. If timezone offset is not given, GMT (0000) is assumed.",
+            "description": "Date/time format based on RFC3339 and ISO ISO8601, with an optional timezone in the format 'yyyy-MM-ddTHH:mm:ss[+-]ZH:ZM'. If timezone offset is not given, GMT (+00:00) is assumed.",
             "pattern": "^(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})?$"
         },
         "version": {
@@ -952,7 +952,7 @@
                 ],
                 "properties": {
                     "time": {
-                        "description": "Timestamp representing when the event in the timeline occurred. The timestamp format is based on RFC3339 and ISO ISO8601, with an optional timezone. yyyy-MM-ddTHH:mm:ssZZZZ - if the timezone offset is not given, GMT (0000) is assumed.",
+                        "description": "Timestamp representing when the event in the timeline occurred. The timestamp format is based on RFC3339 and ISO ISO8601, with an optional timezone. yyyy-MM-ddTHH:mm:ss[+-]ZH:ZM - if the timezone offset is not given, GMT (+00:00) is assumed.",
                         "$ref": "#/definitions/timestamp"
                     },
                     "lang": {


### PR DESCRIPTION
The change clarifies that there is a '+' or '-' before the timezone offset, and that there is a ':' in between the hours ("ZH") part of the timezone offset and the minutes ("ZM") part of the timezone offset. Also, the GMT example is written with this syntax.