### PR TITLE
Disallow use of `.` in property names

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -561,7 +561,7 @@
                 "references"
             ],
             "patternProperties": {
-                "^x_[^.$]*$": {}
+                "^x_[^.]*$": {}
             },
             "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
@@ -592,7 +592,7 @@
                 "rejectedReasons"
             ],
             "patternProperties": {
-                "^x_[^.$]*$": {}
+                "^x_[^.]*$": {}
             },
             "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
@@ -665,7 +665,7 @@
             ],
             "minProperties": 2,
             "patternProperties": {
-                "^x_[^.$]*$": {}
+                "^x_[^.]*$": {}
             },
             "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false

--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -563,6 +563,7 @@
             "patternProperties": {
                 "^x_[^.$]*$": {}
             },
+            "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
         },
         "cnaRejectedContainer": {
@@ -593,6 +594,7 @@
             "patternProperties": {
                 "^x_[^.$]*$": {}
             },
+            "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
         },
         "adpContainer": {
@@ -665,6 +667,7 @@
             "patternProperties": {
                 "^x_[^.$]*$": {}
             },
+            "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
         },
         "affected": {
@@ -1111,7 +1114,8 @@
             "type": "string",
             "minLength": 2,
             "maxLength": 128,
-            "pattern": "^x_.*$"
+            "pattern": "^x_.*$",
+            "$comment": "These values are not used as JSON property names, so there is not a need to work-around property naming limitations in some common implementations."
         },
         "cnaTags": {
             "type": "array",

--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -561,7 +561,7 @@
                 "references"
             ],
             "patternProperties": {
-                "^x_[^.]*$": {}
+                "^x_[^.$]*$": {}
             },
             "additionalProperties": false
         },
@@ -591,7 +591,7 @@
                 "rejectedReasons"
             ],
             "patternProperties": {
-                "^x_[^.]*$": {}
+                "^x_[^.$]*$": {}
             },
             "additionalProperties": false
         },
@@ -663,7 +663,7 @@
             ],
             "minProperties": 2,
             "patternProperties": {
-                "^x_[^.]*$": {}
+                "^x_[^.$]*$": {}
             },
             "additionalProperties": false
         },
@@ -738,7 +738,7 @@
             "description": "A description with lang set to an English language (en, en_US, en_UK, and so on).",
             "properties": {"lang": {"$ref": "#/definitions/englishLanguage"}},
             "required": ["lang"],
-            "additionalProperties": false
+            "$comment": "Cannot use additionalProperties: false here, as this prevents the other properties used by /definitions/description."
         },
         "descriptions": {
             "type": "array",

--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -563,7 +563,7 @@
             "patternProperties": {
                 "^x_[^.]*$": {}
             },
-            "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
+            "$comment": "The character . is restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
         },
         "cnaRejectedContainer": {
@@ -594,7 +594,7 @@
             "patternProperties": {
                 "^x_[^.]*$": {}
             },
-            "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
+            "$comment": "The character . is restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
         },
         "adpContainer": {
@@ -667,7 +667,7 @@
             "patternProperties": {
                 "^x_[^.]*$": {}
             },
-            "$comment": "The characters .$ are restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
+            "$comment": "The character . is restricted in names allowed by patternProperties to work-around naming limitations in some common implementations.",
             "additionalProperties": false
         },
         "affected": {


### PR DESCRIPTION
Enhanced the property patterns to disallow `$`.

Resolves #209.