### PR TITLE
Prevent leading and trailing whitespace in string values, and whitespace-only string values

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -28,7 +28,8 @@
                     "description": "User created name for the reference, often the title of the page.",
                     "type": "string",
                     "maxLength": 512,
-                    "minLength": 1
+                    "minLength": 1,
+                    "pattern": "^(?:\\S|\\S.*\\S)$"
                 },
                 "tags": {
                     "description": "An array of one or more tags that describe the resource referenced by 'url'.",
@@ -65,7 +66,8 @@
             "description": "A 2-32 character name that can be used to complement an organization's UUID.",
             "type": "string",
             "minLength": 2,
-            "maxLength": 32
+            "maxLength": 32,
+            "pattern": "^(?:\\S|\\S.*\\S)$"
         },
         "datestamp": {
             "description": "Date/time format based on RFC3339 and ISO ISO8601.",
@@ -83,7 +85,8 @@
             "description": "A single version of a product, as expressed in its own version numbering scheme.",
             "type": "string",
             "minLength": 1,
-            "maxLength": 1024
+            "maxLength": 1024,
+            "pattern": "^(?:\\S|\\S.*\\S)$"
         },
         "status": {
             "description": "The vulnerability status of a given version or range of versions of a product. The statuses 'affected' and 'unaffected' indicate that the version is affected or unaffected by the vulnerability. The status 'unknown' indicates that it is unknown or unspecified whether the given version is affected. There can be many reasons for an 'unknown' status, including that an investigation has not been undertaken or that a vendor has not disclosed the status.",
@@ -118,7 +121,8 @@
                     "type": "string",
                     "description": "Name of the affected product.",
                     "minLength": 1,
-                    "maxLength": 2048
+                    "maxLength": 2048,
+                    "pattern": "^(?:\\S|\\S.*\\S)$"
                 },
                 "collectionURL": {
                     "description": "URL identifying a package collection (determines the meaning of packageName).",
@@ -203,7 +207,7 @@
                         "title": "CPE Name",
                         "type": "string",
                         "description":"Common Platform Enumeration (CPE) Name in either 2.2 or 2.3 format",
-                        "pattern": "([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9._\\-~%]*){0,6})|(cpe:2\\.3:[aho*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){4})",
+                        "pattern": "^([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9._\\-~%]*){0,6})|(cpe:2\\.3:[aho*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-._]|(\\\\[\\\\*?!\"#$%&'()+,/:;<=>@\\[\\]\\^`{|}~]))+(\\?*|\\*?))|[*\\-])){4})$",
                         "minLength": 1,
                         "maxLength": 2048
                     }
@@ -216,7 +220,8 @@
                         "type": "string",
                         "description": "Name of the affected component, feature, module, sub-component, sub-product, API, command, utility, program, or functionality (optional).",
                         "minLength": 1,
-                        "maxLength": 4096
+                        "maxLength": 4096,
+                        "pattern": "^(?:\\S|\\S.*\\S)$"
                     }
                 },
                 "programFiles": {
@@ -227,7 +232,8 @@
                         "description": "Name or path or location of the affected source code file.",
                         "type": "string",
                         "minLength": 1,
-                        "maxLength": 1024
+                        "maxLength": 1024,
+                        "pattern": "^(?:\\S|\\S.*\\S)$"
                     }
                 },
                 "programRoutines": {
@@ -245,7 +251,8 @@
                                 "type": "string",
                                 "description": "Name of the affected source code file, function, method, subroutine, or procedure.",
                                 "minLength": 1,
-                                "maxLength": 4096
+                                "maxLength": 4096,
+                                "pattern": "^(?:\\S|\\S.*\\S)$"
                             }
                         }
                     }
@@ -309,6 +316,7 @@
                                 "description": "The version numbering system used for specifying the range. This defines the exact semantics of the comparison (less-than) operation on versions, which is required to understand the range itself. 'Custom' indicates that the version type is unspecified and should be avoided whenever possible. It is included primarily for use in conversion of older data files.",
                                 "minLength": 1,
                                 "maxLength": 128,
+                                "pattern": "^(?:\\S|\\S.*\\S)$",
                                 "examples": [
                                     "custom",
                                     "git",
@@ -505,7 +513,8 @@
                     "type": "string",
                     "description": "A title, headline, or a brief phrase summarizing the CVE record. Eg., Buffer overflow in Example Soft.",
                     "minLength": 1,
-                    "maxLength": 256
+                    "maxLength": 256,
+                    "pattern": "^(?:\\S|\\S.*\\S)$"
                 },
                 "descriptions": {
                     "$ref": "#/definitions/descriptions"
@@ -609,7 +618,8 @@
                     "type": "string",
                     "description": "A title, headline, or a brief phrase summarizing the information in an ADP container.",
                     "minLength": 1,
-                    "maxLength": 256
+                    "maxLength": 256,
+                    "pattern": "^(?:\\S|\\S.*\\S)$"
                 },
                 "descriptions": {
                     "$ref": "#/definitions/descriptions"
@@ -697,6 +707,7 @@
                                 "title": "Media type",
                                 "minLength": 1,
                                 "maxLength": 256,
+                                "pattern": "^(?:\\S|\\S.*\\S)$",
                                 "description": "RFC2046 compliant IANA Media type for eg., text/markdown, text/html.",
                                 "examples": [
                                     "text/markdown",
@@ -716,7 +727,8 @@
                                 "type": "string",
                                 "description": "Supporting media content, up to 16K. If base64 is true, this field stores base64 encoded data.",
                                 "minLength": 1,
-                                "maxLength": 16384
+                                "maxLength": 16384,
+                                "pattern": "^(?:\\S|\\S.*\\S)$"
                             }
                         },
                         "required": [
@@ -772,7 +784,8 @@
                                     "type": "string",
                                     "description": "Text description of problemType, or title from CWE or OWASP.",
                                     "minLength": 1,
-                                    "maxLength": 4096
+                                    "maxLength": 4096,
+                                    "pattern": "^(?:\\S|\\S.*\\S)$"
                                 },
                                 "cweId": {
                                     "type": "string",
@@ -785,7 +798,8 @@
                                     "type": "string",
                                     "description": "Problemtype source, text, OWASP, CWE, etc.,",
                                     "minLength": 1,
-                                    "maxLength": 128
+                                    "maxLength": 128,
+                                    "pattern": "^(?:\\S|\\S.*\\S)$"
                                 },
                                 "references": {"$ref": "#/definitions/references"}
                             },
@@ -861,7 +875,8 @@
                         "type": "string",
                         "description": "Name of the scoring format. This provides a bit of future proofing. Additional properties are not prohibited, so this will support the inclusion of proprietary formats. It also provides an easy future conversion mechanism when future score formats become part of the schema. example: cvssV44, format = 'cvssV44', other = cvssV4_4 JSON object. In the future, the other properties can be converted to score properties when they become part of the schema.",
                         "minLength": 1,
-                        "maxLength": 64
+                        "maxLength": 64,
+                        "pattern": "^(?:\\S|\\S.*\\S)$"
                     },
                     "scenarios": {
                         "type": "array",
@@ -877,7 +892,8 @@
                                     "default": "GENERAL",
                                     "description": "Description of the scenario this metrics object applies to. If no specific scenario is given, GENERAL is used as the default and applies when no more specific metric matches.",
                                     "minLength": 1,
-                                    "maxLength": 4096
+                                    "maxLength": 4096,
+                                    "pattern": "^(?:\\S|\\S.*\\S)$"
                                 }
                             },
                             "required": [
@@ -901,7 +917,8 @@
                                 "description": "Name of the non-standard impact metrics format used.",
                                 "type": "string",
                                 "minLength": 1,
-                                "maxLength": 128
+                                "maxLength": 128,
+                                "pattern": "^(?:\\S|\\S.*\\S)$"
                             },
                             "content": {
                                 "type": "object",
@@ -996,7 +1013,8 @@
                     "value": {
                         "type": "string",
                         "minLength": 1,
-                        "maxLength": 4096
+                        "maxLength": 4096,
+                        "pattern": "^(?:\\S|\\S.*\\S)$"
                     },
                     "user": {
                         "description": "UUID of the user being credited if present in the CVE User Registry (optional). This UUID can be used to lookup the user record in the user registry service.",
@@ -1060,17 +1078,19 @@
                         "type": "string",
                         "description": "The name of the taxonomy.",
                         "minLength": 1,
-                        "maxLength": 128
+                        "maxLength": 128,
+                        "pattern": "^(?:\\S|\\S.*\\S)$"
                     },
                     "taxonomyVersion": {
                         "type": "string",
                         "description": "The version of taxonomy the identifiers come from.",
                         "minLength": 1,
-                        "maxLength": 128
+                        "maxLength": 128,
+                        "pattern": "^(?:\\S|\\S.*\\S)$"
                     },
                     "taxonomyRelations": {
                         "type": "array",
-                        "description": "",
+                        "description": "The taxonomy relationship type.",
                         "minItems": 1,
                         "uniqueItems": true,
                         "items": {
@@ -1086,19 +1106,22 @@
                                     "type": "string",
                                     "description": "Identifier of the item in the taxonomy.  Used as the subject of the relationship.",
                                     "minLength": 1,
-                                    "maxLength": 2048
+                                    "maxLength": 2048,
+                                    "pattern": "^(?:\\S|\\S.*\\S)$"
                                 },
                                 "relationshipName": {
                                     "type": "string",
                                     "description": "A description of the relationship.",
                                     "minLength": 1,
-                                    "maxLength": 128
+                                    "maxLength": 128,
+                                    "pattern": "^(?:\\S|\\S.*\\S)$"
                                 },
                                 "relationshipValue": {
                                     "type": "string",
                                     "description": "The target of the relationship.  Can be the CVE ID or another taxonomy identifier.",
                                     "minLength": 1,
-                                    "maxLength": 2048
+                                    "maxLength": 2048,
+                                    "pattern": "^(?:\\S|\\S.*\\S)$"
                                 }
                             }
                         }


### PR DESCRIPTION
Added patterns to prevent string values from start or ending with whitespace.  These strings cannot just contain whitespace either,

Resolves #232