### PR TITLE
Make README links clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 cve-schema specifies the CVE JSON record format. This is the blueprint for a rich set of JSON data that can be submitted by CVE Numbering Authorities (CNAs) and Authorized Data Publishers (ADPs) to describe a CVE record. Some examples of CVE record data include CVE ID number, affected product(s), affected version(s), and public references. While those specific items are required when assigning a CVE, there are many other optional data in the schema that can be used to enrich CVE records for community benefit.
 
-Learn more about the CVE program at: https://www.cve.org/
+Learn more about the CVE program at [cve.org](https://www.cve.org/)
 
-This CVE JSON record format is defined using JSON Schema. Learn more about JSON Schema at: https://json-schema.org/ .
+This CVE JSON record format is defined using JSON Schema. Learn more about JSON Schema [here](https://json-schema.org/)
 
-The latest version of the record format is 5.0. It is specified in the JSON schema at https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json
+The latest version of the record format is 5.0. It is specified in the JSON schema at [CVE_JSON_5.0_schema.json](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json)
 
-A single schema file with bundled dependencies is at https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/docs/CVE_JSON_5.0_bundled.json
+A single schema file with bundled dependencies is at [CVE_JSON_5.0_bundled.json](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/docs/CVE_JSON_5.0_bundled.json)
 
-Documentation about this format is available at https://cveproject.github.io/cve-schema/schema/v5.0/docs/
+Documentation about this format is available in [docs](https://cveproject.github.io/cve-schema/schema/v5.0/docs/)
 
-A mindmap version of the CVE record structure is at https://cveproject.github.io/cve-schema/schema/v5.0/docs/mindmap.html
+A mindmap version of the CVE record structure is at [mindmap](https://cveproject.github.io/cve-schema/schema/v5.0/docs/mindmap.html)
 
-A basic example of a full record in 5.0 format with minimally required fields is available at https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/full-record-basic-example.json
+A basic example of a full record in 5.0 format with minimally required fields is available at [full-record-basic-example.json](https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/full-record-basic-example.json)
 
-An advanced example of a full record in 5.0 format is available at https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/full-record-advanced-example.json
+An advanced example of a full record in 5.0 format is available at [full-record-advanced-example.json](https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/full-record-advanced-example.json)
 
-A basic example of a cnaContainer, to be used with CVE Services, is available at https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/cnaContainer-basic-example.json
+A basic example of a cnaContainer, to be used with CVE Services, is available at [cnaContainer-basic-example.json](https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/cnaContainer-basic-example.json)
 
-An advanced example of a cnaContainer, to be used with CVE Services, is available at https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/cnaContainer-advanced-example.json
+An advanced example of a cnaContainer, to be used with CVE Services, is available at [cnaContainer-advanced-example.json](https://github.com/cveproject/cve-schema/blob/master/schema/v5.0/docs/cnaContainer-advanced-example.json)
 
-More details about Product and Version Encodings in CVE JSON 5.0 record is at https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/docs/versions.md
+More details about Product and Version Encodings in CVE JSON 5.0 record is at [versions.md](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/docs/versions.md)


### PR DESCRIPTION
This PR turns all non-clickable links into clickable ones generally using the link's basename as the clickable text. Without this change, or something similar, all links on https://cveproject.github.io/cve-schema/ must be selected and copied into a new browser tab/window