### PR TITLE
CVSSv4.0 into CVE json 5.1.0 schema

### DIFF
--- a/schema/v5.0/CVE_JSON_5.0_schema.json
+++ b/schema/v5.0/CVE_JSON_5.0_schema.json
@@ -830,8 +830,11 @@
             "uniqueItems": true,
             "items": {
                 "type": "object",
-                "description": "This is impact type information (e.g. a text description, CVSSv2, CVSSv3, etc.). Must contain: At least one entry, can be text, CVSSv2, CVSSv3, others may be added.",
+                "description": "This is impact type information (e.g. a text description, CVSSv2, CVSSv3, CVSSv4, etc.). Must contain: At least one entry, can be text, CVSSv2, CVSSv3, CVSSv4, others may be added.",
                 "anyOf": [
+                    {
+                        "required": ["cvssV4_0"]
+                    },
                     {
                         "required": ["cvssV3_1"]
                     },
@@ -875,6 +878,7 @@
                             ]
                         }
                     },
+                    "cvssV4_0": {"$ref": "file:imports/cvss/cvss-v4.0.json"},
                     "cvssV3_1": {"$ref": "file:imports/cvss/cvss-v3.1.json"},
                     "cvssV3_0": {"$ref": "file:imports/cvss/cvss-v3.0.json"},
                     "cvssV2_0": {"$ref": "file:imports/cvss/cvss-v2.0.json"},

--- a/schema/v5.0/support/Python3.x_Validator/cvss-v4.0.json
+++ b/schema/v5.0/support/Python3.x_Validator/cvss-v4.0.json
@@ -1,0 +1,182 @@
+{
+    "license": [
+        "Copyright (c) 2023, FIRST.ORG, INC.",
+        "All rights reserved.",
+        "",
+        "Redistribution and use in source and binary forms, with or without modification, are permitted provided that the ",
+        "following conditions are met:",
+        "1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following ",
+        "   disclaimer.",
+        "2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the ",
+        "   following disclaimer in the documentation and/or other materials provided with the distribution.",
+        "3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote ",
+        "   products derived from this software without specific prior written permission.",
+        "",
+        "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, ",
+        "INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE ",
+        "DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, ",
+        "SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR ",
+        "SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, ",
+        "WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE ",
+        "OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    ],
+
+    "$schema": "https://json-schema.org/draft/2020-12/schema#",
+    "title": "JSON Schema for Common Vulnerability Scoring System version 4.0",
+    "$id": "https://www.first.org/cvss/cvss-v4.0.json?20231002",
+    "type": "object",
+    "definitions": {
+        "attackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT", "LOCAL", "PHYSICAL" ]
+        },
+        "modifiedAttackVectorType": {
+            "type": "string",
+            "enum": [ "NETWORK", "ADJACENT", "LOCAL", "PHYSICAL", "NOT_DEFINED" ]
+        },
+        "attackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW" ]
+        },
+        "modifiedAttackComplexityType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NOT_DEFINED" ]
+        },
+        "attackRequirementsType": {
+            "type": "string",
+            "enum": [ "NONE", "PRESENT" ]
+        },
+        "modifiedAttackRequirementsType": {
+            "type": "string",
+            "enum": [ "NONE", "PRESENT", "NOT_DEFINED" ]
+        },
+        "privilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE" ]
+        },
+        "modifiedPrivilegesRequiredType": {
+            "type": "string",
+            "enum": [ "HIGH", "LOW", "NONE", "NOT_DEFINED" ]
+        },
+        "userInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "PASSIVE", "ACTIVE" ]
+        },
+        "modifiedUserInteractionType": {
+            "type": "string",
+            "enum": [ "NONE", "PASSIVE", "ACTIVE", "NOT_DEFINED" ]
+        },
+        "vulnCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedVulnCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "subCiaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH" ]
+        },
+        "modifiedSubCType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "NOT_DEFINED" ]
+        },
+        "modifiedSubIaType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "HIGH", "SAFETY", "NOT_DEFINED" ]
+        },
+        "exploitMaturityType": {
+            "type": "string",
+            "enum": [ "UNREPORTED", "PROOF_OF_CONCEPT", "ATTACKED", "NOT_DEFINED" ]
+        },
+        "ciaRequirementType": {
+            "type": "string",
+            "enum": [ "LOW", "MEDIUM", "HIGH", "NOT_DEFINED" ]
+        },
+        "safetyType": {
+            "type": "string",
+            "enum": [ "NEGLIGIBLE", "PRESENT", "NOT_DEFINED" ]
+        },
+        "automatableType": {
+            "type": "string",
+            "enum": [ "NO", "YES", "NOT_DEFINED" ]
+        },
+        "recoveryType": {
+            "type": "string",
+            "enum": [ "AUTOMATIC", "USER", "IRRECOVERABLE", "NOT_DEFINED" ]
+        },
+        "valueDensityType": {
+            "type": "string",
+            "enum": [ "DIFFUSE", "CONCENTRATED", "NOT_DEFINED" ]
+        },
+        "vulnerabilityResponseEffortType": {
+            "type": "string",
+            "enum": [ "LOW", "MODERATE", "HIGH", "NOT_DEFINED" ]
+        },
+        "providerUrgencyType": {
+            "type": "string",
+            "enum": [ "CLEAR", "GREEN", "AMBER", "RED", "NOT_DEFINED" ]
+        },
+        "scoreType": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 10,
+            "multipleOf": 0.1
+        },
+        "severityType": {
+            "type": "string",
+            "enum": [ "NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL" ]
+        }
+    },
+    "properties": {
+        "version": {
+            "description": "CVSS Version",
+            "type": "string",
+            "enum": [ "4.0" ]
+        },
+        "vectorString": {
+            "type": "string",
+            "pattern": "^CVSS:4[.]0/((AV:[NALP]|AC:[LH]|AT:[NP]|PR:[NLH]|UI:[NPA]|V[CIA]:[NLH]|S[CIA]:[NLH]|E:[XUPA]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MAT:[XNP]|MPR:[XNLH]|MUI:[XNPA]|MV[CIA]:[XNLH]|MSC:[XNLH]|MS[IA]:[XNLHS]|S:[XNP]|AU:[XNY]|R:[XAUI]|V:[XDC]|RE:[XLMH]|U:[WGAR])/)*(AV:[NALP]|AC:[LH]|AT:[NP]|PR:[NLH]|UI:[NPA]|V[CIA]:[NLH]|S[CIA]:[NLH]|E:[XUPA]|[CIA]R:[XLMH]|MAV:[XNALP]|MAC:[XLH]|MAT:[XNP]|MPR:[XNLH]|MUI:[XNPA]|MV[CIA]:[XNLH]|MSC:[XNLH]|MS[IA]:[XNLHS]|S:[XNP]|AU:[XNY]|R:[XAUI]|V:[XDC]|RE:[XLMH]|U:[WGAR])$"
+        },
+        "attackVector":                   { "$ref": "#/definitions/attackVectorType" },
+        "attackComplexity":               { "$ref": "#/definitions/attackComplexityType" },
+        "attackRequirements":             { "$ref": "#/definitions/attackRequirementsType" },
+        "privilegesRequired":             { "$ref": "#/definitions/privilegesRequiredType" },
+        "userInteraction":                { "$ref": "#/definitions/userInteractionType" },
+        "vulnConfidentialityImpact":      { "$ref": "#/definitions/vulnCiaType" },
+        "vulnIntegrityImpact":            { "$ref": "#/definitions/vulnCiaType" },
+        "vulnAvailabilityImpact":         { "$ref": "#/definitions/vulnCiaType" },
+        "subConfidentialityImpact":       { "$ref": "#/definitions/subCiaType" },
+        "subIntegrityImpact":             { "$ref": "#/definitions/subCiaType" },
+        "subAvailabilityImpact":          { "$ref": "#/definitions/subCiaType" },
+        "baseScore":                      { "$ref": "#/definitions/scoreType" },
+        "baseSeverity":                   { "$ref": "#/definitions/severityType" },
+        "exploitMaturity":                { "$ref": "#/definitions/exploitMaturityType" },
+        "threatScore":                    { "$ref": "#/definitions/scoreType" },
+        "threatSeverity":                 { "$ref": "#/definitions/severityType" },
+        "confidentialityRequirement":     { "$ref": "#/definitions/ciaRequirementType" },
+        "integrityRequirement":           { "$ref": "#/definitions/ciaRequirementType" },
+        "availabilityRequirement":        { "$ref": "#/definitions/ciaRequirementType" },
+        "modifiedAttackVector":           { "$ref": "#/definitions/modifiedAttackVectorType" },
+        "modifiedAttackComplexity":       { "$ref": "#/definitions/modifiedAttackComplexityType" },
+        "modifiedAttackRequirements":     { "$ref": "#/definitions/modifiedAttackRequirementsType" },
+        "modifiedPrivilegesRequired":     { "$ref": "#/definitions/modifiedPrivilegesRequiredType" },
+        "modifiedUserInteraction":        { "$ref": "#/definitions/modifiedUserInteractionType" },
+        "modifiedVulnConfidentialityImpact":  { "$ref": "#/definitions/modifiedVulnCiaType" },
+        "modifiedVulnIntegrityImpact":        { "$ref": "#/definitions/modifiedVulnCiaType" },
+        "modifiedVulnAvailabilityImpact":     { "$ref": "#/definitions/modifiedVulnCiaType" },
+        "modifiedSubConfidentialityImpact":   { "$ref": "#/definitions/modifiedSubCType"  },
+        "modifiedSubIntegrityImpact":         { "$ref": "#/definitions/modifiedSubIaType" },
+        "modifiedSubAvailabilityImpact":      { "$ref": "#/definitions/modifiedSubIaType" },
+        "environmentalScore":             { "$ref": "#/definitions/scoreType" },
+        "environmentalSeverity":          { "$ref": "#/definitions/severityType" },
+        "Safety":                         { "$ref": "#/definitions/safetyType" },
+        "Automatable":                    { "$ref": "#/definitions/automatableType" },
+        "Recovery":                       { "$ref": "#/definitions/recoveryType" },
+        "valueDensity":                   { "$ref": "#/definitions/valueDensityType" },
+        "vulnerabilityResponseEffort":    { "$ref": "#/definitions/vulnerabilityResponseEffortType" },
+        "providerUrgency":                { "$ref": "#/definitions/providerUrgencyType" }
+    },
+    "required": [ "version", "vectorString", "baseScore", "baseSeverity" ]
+}

--- a/schema/v5.0/support/schema2markmap/schema-bundle.js
+++ b/schema/v5.0/support/schema2markmap/schema-bundle.js
@@ -6,9 +6,11 @@ var fs = require('fs');
 async function schemaBundle() {
         var cveSchemaBundle = await rp.bundle(process.argv[2]);
         var metricProperties = cveSchemaBundle.definitions.metrics.items.properties;
+        delete metricProperties.cvssV4_0.id;
         delete metricProperties.cvssV3_1.id;
         delete metricProperties.cvssV3_0.id;
         delete metricProperties.cvssV2_0.id;
+        delete metricProperties.cvssV4_0.license;
         delete metricProperties.cvssV3_1.license;
         delete metricProperties.cvssV3_0.license;
         delete metricProperties.cvssV2_0.license;


### PR DESCRIPTION
CVE json 5.1.0 schema changes

Some changes are made in:
schema\v5.0\CVE_JSON_5.0_schema.json
schema\V5.0\imports\cvss\cvss-v4.0.json
schema\V5.0\support\Python3.x_Validator\cvss-v4.0.json
schema\v5.0\support\schema2markmap

Other files with CVSS are not covered in this pull request

