### PR TITLE
Update README to make URLs clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,31 @@ cve-schema specifies the CVE record format. This is the blueprint for a rich set
 
 ### Learn
 
-Learn more about the CVE program at: https://www.cve.org/
+Learn more about the CVE program at: [cve.org](https://www.cve.org/)
 
-This CVE record format is defined using JSON Schema. Learn more about JSON Schema at: https://json-schema.org/ .
+This CVE record format is defined using JSON Schema. Learn more about JSON Schema at: [json-schema.org](https://json-schema.org/).
 
 ### Latest
 
-The latest version of the record format is 5.1.0. It is specified in the JSON schema at https://github.com/CVEProject/cve-schema/blob/master/schema/CVE_Record_Format.json
+The latest version of the record format is 5.1.0. It is specified in the [CVE Record Format JSON schema](https://github.com/CVEProject/cve-schema/blob/master/schema/CVE_Record_Format.json)
 
-A single schema file with bundled dependencies is at https://github.com/CVEProject/cve-schema/blob/master/schema/docs/CVE_Record_Format_bundled.json
+A single schema file with bundled schema dependencies can always be found [here](https://github.com/CVEProject/cve-schema/blob/master/schema/docs/CVE_Record_Format_bundled.json)
 
 ### Documentation and Guidance
 
-Documentation about this format is available at https://cveproject.github.io/cve-schema/schema/docs/
+Additional [Documentation](https://cveproject.github.io/cve-schema/schema/docs/) about the format is also available.
 
-A mindmap version of the CVE record structure is at https://cveproject.github.io/cve-schema/schema/docs/mindmap.html
+The CVE record structure is also viewable as an interactive [mindmap](https://cveproject.github.io/cve-schema/schema/docs/mindmap.html).
 
-More details about Product and Version Encodings in CVE JSON 5.1.0 record is at https://github.com/CVEProject/cve-schema/blob/master/schema/docs/versions.md
+More details about Product and Product Version Formats/Encodings in CVE JSON 5.1.0 record can be found [here](https://github.com/CVEProject/cve-schema/blob/master/schema/docs/versions.md)
 
 ### Examples
 
-A basic example of a full record in 5.1.0 format with minimally required fields is available at https://github.com/cveproject/cve-schema/blob/master/schema/docs/full-record-basic-example.json
+A [basic example of a full record in 5.1.0 format with minimally required fields](https://github.com/cveproject/cve-schema/blob/master/schema/docs/full-record-basic-example.json)
 
-An advanced example of a full record in 5.1.0 format is available at https://github.com/cveproject/cve-schema/blob/master/schema/docs/full-record-advanced-example.json
+An [advanced example of a full record in 5.1.0 format](https://github.com/cveproject/cve-schema/blob/master/schema/docs/full-record-advanced-example.json)
 
-A basic example of a cnaContainer, to be used with CVE Services, is available at https://github.com/cveproject/cve-schema/blob/master/schema/docs/cnaContainer-basic-example.json
+A [basic example of a cnaContainer only](https://github.com/cveproject/cve-schema/blob/master/schema/docs/cnaContainer-basic-example.json), to be used with CVE Services
 
-An advanced example of a cnaContainer, to be used with CVE Services, is available at https://github.com/cveproject/cve-schema/blob/master/schema/docs/cnaContainer-advanced-example.json
+An [advanced example of a cnaContainer only](https://github.com/cveproject/cve-schema/blob/master/schema/docs/cnaContainer-advanced-example.json
+), to be used with CVE Services


### PR DESCRIPTION
At a minimum, all URLs should be clickable. I took the liberty of working the links into the wording, but it could also be done by just linkifying all the URLs with the `[link_text](url)` syntax.