### PR TITLE
schema/support/schema2markmap/schema-bundle.js Update

### DIFF
--- a/schema/support/schema2markmap/schema-bundle.js
+++ b/schema/support/schema2markmap/schema-bundle.js
@@ -23,13 +23,13 @@ async function schemaBundle() {
         delete metricProperties.cvssV2_0.license;
 
 
-        fs.writeFile(`${dirName}/CVE_Record_Format.json`,
+        fs.writeFile(`${dirName}/CVE_Record_Format_bundled.json`,
                 JSON.stringify(cveSchemaBundle, null, 2),
                 err => {
                         if(err)
                                 throw err;
                         else 
-                                console.log('CVE_Record_Format.json created');
+                                console.log('CVE_Record_Format_bundled.json created');
                         }
         );
 


### PR DESCRIPTION
'CVE_Record_Format.json' should have been 'CVE_Record_Format_bundled.json.' Looks like i accidentally removed '_bundled' when moving from the CVE_JSON to CVE_Record_Format naming.