### PR TITLE
Document CVD ID format in CVE_Record_Format.json

### DIFF
--- a/schema/CVE_Record_Format.json
+++ b/schema/CVE_Record_Format.json
@@ -51,7 +51,7 @@
         },
         "cveId": {
             "type": "string",
-            "description":"The official CVE identifier contains the string 'CVE' , followed by the year, followed by a 4 to 19 digit number. Note that the year-part of the identifier should indicate either the year the vulnerability was discovered, or the year the CVE ID is published in. CVE IDs must be unique."
+            "description":"The official CVE identifier contains the string 'CVE', followed by the year, followed by a 4 to 19 digit number. Note that the year-part of the identifier should indicate either the year the vulnerability was discovered, or the year the CVE ID is published in. CVE IDs must be unique.",
             "pattern": "^CVE-[0-9]{4}-[0-9]{4,19}$"
         },
         "cpe22and23": {

--- a/schema/CVE_Record_Format.json
+++ b/schema/CVE_Record_Format.json
@@ -51,6 +51,7 @@
         },
         "cveId": {
             "type": "string",
+            "description":"The official CVE identifier contains the string 'CVE' , followed by the year, followed by a 4 to 19 digit number. Note that the year-part of the identifier should indicate either the year the vulnerability was discovered, or the year the CVE ID is published in. CVE IDs must be unique."
             "pattern": "^CVE-[0-9]{4}-[0-9]{4,19}$"
         },
         "cpe22and23": {


### PR DESCRIPTION
There does not appear to be any documentation describing the `cveID` field of a properly formatted CVE JSON object. This PR captures the intent of the year-part of a CVE ID, as well as the reminder that CVE IDs should be unique.

Note that this documentation specifically is based on a recommendation made by the CNA Coordination Working Group to the CVE Board, at a board meeting on June 22, 2022. See those board meeting notes here:

https://cve.mitre.org/community/board/meeting_summaries/22_June_2022.pdf

(Note also that the CNACWG is now known as the COOP WG.)

There are many opinions on what the year-part of a CVE ID should be. This seems to be a fine place to encode the two most common uses of the year-part, in a concise way, to help developers of CVE-writing and parsing applications.

Lacking guidance on the year-part would mean that a valid CVE could be CVE-1010-1010101010 . While such a CVE ID looks pretty cool, it ignores the intended purpose of the year part.

There is a lot more to say about the structure of a CVE ID, such as the value of creating patterns in the sequence number part, about how CVE IDs should not be in the distant future or past, and other things, but JSON descriptions tend to favor being concise rather than being thorough.

If you wanted, though, you could update line 55 to force a pattern match on `^CVE-(20|19)\d{2}-[0-9]{4,19}$` to at least keep CVE IDs inside this century or the last century. (And let a future version of the schema deal with vulns published against flying cars and robot maids.)