### PR TITLE
Rejected example CVE Record is inconsistent with 4.5.3.7 in CNA Rules…

### DIFF
--- a/schema/docs/cnaContainer-rejected-example.json
+++ b/schema/docs/cnaContainer-rejected-example.json
@@ -7,7 +7,7 @@
     "rejectedReasons": [
       {
         "lang": "en",
-        "value": "This CVE ID has been rejected or withdrawn by its CVE Numbering Authority."
+        "value": "This CVE Record has been rejected because it is a duplicate of CVE-1900-12345."
       }
     ]
   }


### PR DESCRIPTION
… 4.0

Updated rejected example CVE Record to include a better rejectedReasons value. Fixes Issue #313