### PR TITLE
Updated naming for CVE Record Format index.js mindmap

### DIFF
--- a/schema/support/schema2markmap/index.js
+++ b/schema/support/schema2markmap/index.js
@@ -1,5 +1,5 @@
 // Author: Chandan BN (c) 2021
-//   (1) convert CVE JSON schema to a mindmap
+//   (1) convert CVE Record Format JSON schema to a mindmap
 
 var ml = require('markmap-lib')
 var Transformer = ml.Transformer;
@@ -16,7 +16,7 @@ const { Markmap, loadCSS, loadJS } = markmap;
 
 let forDeletion = ['properties', 'items', 'anyOf', 'allOf', 'oneOf'];
 
-var markdown = "# CVE JSON Record\n";
+var markdown = "# CVE Record Format\n";
 
 function postfunc(obj, path, parent, parentPath) {
   if (path[1] && isNaN(path[1])) {
@@ -56,7 +56,7 @@ async function schemaMindMap() {
 
   // create mindmap html
   var html = fillTemplate(root, assets);
-  html = html.replace('<title>Markmap</title>', '<title>CVE JSON v5 Mindmap</title>');
+  html = html.replace('<title>Markmap</title>', '<title>CVE Record Format Mindmap</title>');
   console.log(html);
 }
 


### PR DESCRIPTION
The CVE Record Format legacy naming was used in a few places in the mindmap file. Updated to use the correct naming. This fixes Issue #305