### PR TITLE
Include tag property example for advanced record examples

### DIFF
--- a/schema/docs/cnaContainer-advanced-example.json
+++ b/schema/docs/cnaContainer-advanced-example.json
@@ -328,6 +328,9 @@
       "advisory": "ESA-22-11",
       "discovery": "EXTERNAL"
     },
+    "tags": [
+      "unsupported-when-assigned"
+    ],
     "taxonomyMappings": [
       {
         "taxonomyName": "ATT&CK",

--- a/schema/docs/full-record-advanced-example.json
+++ b/schema/docs/full-record-advanced-example.json
@@ -341,6 +341,9 @@
         "advisory": "ESA-22-11",
         "discovery": "EXTERNAL"
       },
+      "tags": [
+        "unsupported-when-assigned"
+      ],
       "taxonomyMappings": [
         {
           "taxonomyName": "ATT&CK",


### PR DESCRIPTION
Added an example of using a tag at the container level. Implements suggestion in Issue #277