### PR TITLE
Add `packageURL` field to product in `affected` array.

### DIFF
--- a/schema/CVE_Record_Format.json
+++ b/schema/CVE_Record_Format.json
@@ -108,19 +108,15 @@
             "description": "Provides information about the set of products and services affected by this vulnerability.",
             "allOf": [
                 {
-                    "allOf": [
-                        {
-                            "anyOf": [
-                                {"required": ["vendor", "product"]},
-                                {"required": ["collectionURL", "packageName"]}
-                            ]
-                        },
-                        {
-                            "anyOf": [
-                                {"required": ["versions"]},
-                                {"required": ["defaultStatus"]}
-                            ]
-                        }
+                    "anyOf": [
+                        {"required": ["vendor", "product"]},
+                        {"required": ["collectionURL", "packageName"]}
+                    ]
+                },
+                {
+                    "anyOf": [
+                        {"required": ["versions"]},
+                        {"required": ["defaultStatus"]}
                     ]
                 }
             ],

--- a/schema/CVE_Record_Format.json
+++ b/schema/CVE_Record_Format.json
@@ -108,16 +108,39 @@
             "description": "Provides information about the set of products and services affected by this vulnerability.",
             "allOf": [
                 {
-                    "anyOf": [
-                        {"required": ["vendor", "product"]},
-                        {"required": ["collectionURL", "packageName"]}
+                    "allOf": [
+                        {
+                            "anyOf": [
+                                {"required": ["vendor", "product"]},
+                                {"required": ["collectionURL", "packageName"]},
+                                {"required": ["packageURL"]}
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {"required": ["versions"]},
+                                {"required": ["defaultStatus"]}
+                            ]
+                        }
                     ]
                 },
                 {
-                    "anyOf": [
-                        {"required": ["versions"]},
-                        {"required": ["defaultStatus"]}
-                    ]
+                    "not": {
+                        "anyOf": [
+                            {
+                                "allOf": [
+                                    {"required": ["packageURL"]},
+                                    {"required": ["collectionURL"]}
+                                ]
+                            },
+                            {
+                                "allOf": [
+                                    {"required": ["packageURL"]},
+                                    {"required": ["packageName"]}
+                                ]
+                            }
+                        ]
+                    }
                 }
             ],
             "properties": {
@@ -361,6 +384,28 @@
                         },
                         "additionalProperties": false
                     }
+                },
+                "packageURL": {
+                    "description": "A Package URL, a unified URL specification for identifying packages hosted by known package hosts.",
+                    "$ref": "#/definitions/uriType",
+                    "examples": [
+                        "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",
+                        "pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie",
+                        "pkg:docker/cassandra@sha256:244fd47e07d1004f0aed9c",
+                        "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
+                        "pkg:gem/jruby-launcher@1.1.2?platform=java",
+                        "pkg:gem/ruby-advisory-db-check@0.12.4",
+                        "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                        "pkg:golang/google.golang.org/genproto#googleapis/api/annotations",
+                        "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?packaging=sources",
+                        "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release",
+                        "pkg:npm/%40angular/animation@12.3.1",
+                        "pkg:npm/foobar@12.3.1",
+                        "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",
+                        "pkg:pypi/django@1.11.1",
+                        "pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25",
+                        "pkg:rpm/opensuse/curl@7.56.1-1.1.?arch=i386&distro=opensuse-tumbleweed"
+                    ]
                 }
             }
         },

--- a/schema/CVE_Record_Format.json
+++ b/schema/CVE_Record_Format.json
@@ -386,25 +386,25 @@
                     }
                 },
                 "packageURL": {
-                    "description": "A Package URL, a unified URL specification for identifying packages hosted by known package hosts.",
+                    "description": "A Package URL, a unified URL specification for identifying packages hosted by known package hosts. The Package URL MUST NOT include a version.",
                     "$ref": "#/definitions/uriType",
                     "examples": [
-                        "pkg:bitbucket/birkenfeld/pygments-main@244fd47e07d1014f0aed9c",
-                        "pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=jessie",
-                        "pkg:docker/cassandra@sha256:244fd47e07d1004f0aed9c",
-                        "pkg:docker/customer/dockerimage@sha256:244fd47e07d1004f0aed9c?repository_url=gcr.io",
-                        "pkg:gem/jruby-launcher@1.1.2?platform=java",
-                        "pkg:gem/ruby-advisory-db-check@0.12.4",
-                        "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c",
+                        "pkg:bitbucket/birkenfeld/pygments-main",
+                        "pkg:deb/debian/curl?arch=i386&distro=jessie",
+                        "pkg:docker/cassandra",
+                        "pkg:docker/customer/dockerimage?repository_url=gcr.io",
+                        "pkg:gem/jruby-launcher?platform=java",
+                        "pkg:gem/ruby-advisory-db-check",
+                        "pkg:github/package-url/purl-spec",
                         "pkg:golang/google.golang.org/genproto#googleapis/api/annotations",
-                        "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?packaging=sources",
-                        "pkg:maven/org.apache.xmlgraphics/batik-anim@1.9.1?repository_url=repo.spring.io/release",
-                        "pkg:npm/%40angular/animation@12.3.1",
-                        "pkg:npm/foobar@12.3.1",
-                        "pkg:nuget/EnterpriseLibrary.Common@6.0.1304",
-                        "pkg:pypi/django@1.11.1",
-                        "pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25",
-                        "pkg:rpm/opensuse/curl@7.56.1-1.1.?arch=i386&distro=opensuse-tumbleweed"
+                        "pkg:maven/org.apache.xmlgraphics/batik-anim?packaging=sources",
+                        "pkg:maven/org.apache.xmlgraphics/batik-anim?repository_url=repo.spring.io/release",
+                        "pkg:npm/%40angular/animation",
+                        "pkg:npm/foobar",
+                        "pkg:nuget/EnterpriseLibrary.Common",
+                        "pkg:pypi/django",
+                        "pkg:rpm/fedora/curl?arch=i386&distro=fedora-25",
+                        "pkg:rpm/opensuse/curl?arch=i386&distro=opensuse-tumbleweed"
                     ]
                 }
             }

--- a/schema/CVE_Record_Format.json
+++ b/schema/CVE_Record_Format.json
@@ -112,8 +112,7 @@
                         {
                             "anyOf": [
                                 {"required": ["vendor", "product"]},
-                                {"required": ["collectionURL", "packageName"]},
-                                {"required": ["packageURL"]}
+                                {"required": ["collectionURL", "packageName"]}
                             ]
                         },
                         {
@@ -123,24 +122,6 @@
                             ]
                         }
                     ]
-                },
-                {
-                    "not": {
-                        "anyOf": [
-                            {
-                                "allOf": [
-                                    {"required": ["packageURL"]},
-                                    {"required": ["collectionURL"]}
-                                ]
-                            },
-                            {
-                                "allOf": [
-                                    {"required": ["packageURL"]},
-                                    {"required": ["packageName"]}
-                                ]
-                            }
-                        ]
-                    }
                 }
             ],
             "properties": {

--- a/schema/docs/cnaContainer-advanced-example.json
+++ b/schema/docs/cnaContainer-advanced-example.json
@@ -37,8 +37,9 @@
           "MacOS",
           "XT-4500"
         ],
-        "collectionURL": "https://example.org/packages",
-        "packageName": "example_enterprise",
+        "collectionURL": "https://npmjs.com",
+        "packageName": "example",
+        "packageURL": "pkg:npm/example",
         "repo": "git://example.org/source/example_enterprise",
         "modules": [
           "Web-Management-Interface"

--- a/schema/docs/full-record-advanced-example.json
+++ b/schema/docs/full-record-advanced-example.json
@@ -50,8 +50,9 @@
             "MacOS",
             "XT-4500"
           ],
-          "collectionURL": "https://example.org/packages",
-          "packageName": "example_enterprise",
+          "collectionURL": "https://npmjs.com",
+          "packageName": "example",
+          "packageURL": "pkg:npm/example",
           "repo": "git://example.org/source/example_enterprise",
           "modules": [
             "Web-Management-Interface"
@@ -162,7 +163,7 @@
               "value": "OS-komand-injekta vundebleco <tt>parseFilename</tt> funkcio de <tt>example.php</tt> en la Web Administrado-Interfaco de Example.org Example Enterprise ĉe Windows, macOS kaj XT-4500 permesas al malproksimaj neaŭtentikigitaj atakantoj eskaladi privilegiojn.<br><br> Ĉi tiu afero efikas:<br><ul><li>1.0-versioj antaŭ 1.0.6</li><li>2.1-versioj de 2.1.6 ĝis 2.1.9.</li></ul>"
             }
           ]
-        }          
+        }
       ],
       "metrics": [
         {


### PR DESCRIPTION
The `affected` array is an array containing `product` objects, which must at minimum include an "identifier" (which may be a composite identifier composed of multiple fields) along with a set of version bounds or a default status. Products may also specify an assortment of additional fields which further constrain the applicability of the CVE to its intended target hardware or software.

Previously, the set of identifiers available were:

- A `vendor` and `product`
- A `collectionURL` and `packageName`

This commit adds support for a new identifier, called `packageURL`, which uses the purl (Package URL) specification. The contents of the commit add this as a new field on the `product` type, with a description and examples, and also update the data constraints on the `product` type, both to make `packageURL` an option to fulfill the identifier requirement already in place on the type, and to ensure that the new `packageURL` field is not mixed with the existing `collectionURL` or `packageName` fields, as they are redundant with `packageURL` and including both increases the possibility of data inconsistency within a single CVE record.

This inclusion of a new `packageURL` type which can be used instead of the existing pair of `collectionURL` and `packageName` would require consumers of CVE records to update their logic both to accept the new field, and to use it in places where they may today use the pair of `collectionURL` and `packageName`.

This commit does not include a regular expression to parse Package URLs specifically. Rather, it reuses the existing `uriType` schema. So we can be sure after validating CVE records against this updated record format that the `packageURL` field is a URL, but not that it is a valid Package URL per the Package URL specification. It would be the responsibility of CVE Services to further validate the field to ensure values match the Package URL specification. We do not perform this validation in-schema due to the complexity of expressing the validation in the form of a regular expression.

This work is submitted as an alternative formulation of the design proposed in the draft RFD on software identifiers [1], and as an alternative to the existing proposals for making the `cpeApplicability` structure generic [2] (instead of it being CPE-specific) and enhancing this new generic applicability structure with support for Package URLs [3].

If this change is accepted, then [2] and [3] should not be accepted.

[1]: https://github.com/CVEProject/cve-schema/pull/407
[2]: https://github.com/CVEProject/cve-schema/pull/391
[3]: https://github.com/CVEProject/cve-schema/pull/397